### PR TITLE
Allow bindings to support content faulting

### DIFF
--- a/Demo/TableView/TableViewDemosBindingsViewController.swift
+++ b/Demo/TableView/TableViewDemosBindingsViewController.swift
@@ -31,8 +31,8 @@ final class TableViewDemosBindingsViewController : UIViewController
         
         self.tableView.setContent { table in
             table += TableView.Section(header: "Demo Section") { rows in
-                rows += TableView.Row(String(self.number), bind: {
-                    Binding(initial: $0, bind: { _ in
+                rows += TableView.Row(String(self.number), bind: { element in
+                    Binding(initial: { element }, bind: { _ in
                         NotificationContext<String,Notification>(name: .incrementedDemo)
                     }, update: { _, _, element in
                         self.number += 1

--- a/Demo/TableView/TableViewDemosBindingsViewController.swift
+++ b/Demo/TableView/TableViewDemosBindingsViewController.swift
@@ -32,7 +32,7 @@ final class TableViewDemosBindingsViewController : UIViewController
         self.tableView.setContent { table in
             table += TableView.Section(header: "Demo Section") { rows in
                 rows += TableView.Row(String(self.number), bind: { element in
-                    Binding(initial: { element }, bind: { _ in
+                    Binding(initial: element, bind: { _ in
                         NotificationContext<String,Notification>(name: .incrementedDemo)
                     }, update: { _, _, element in
                         self.number += 1

--- a/Demo/TableView/TableViewDemosBindingsViewController.swift
+++ b/Demo/TableView/TableViewDemosBindingsViewController.swift
@@ -32,7 +32,7 @@ final class TableViewDemosBindingsViewController : UIViewController
         self.tableView.setContent { table in
             table += TableView.Section(header: "Demo Section") { rows in
                 rows += TableView.Row(String(self.number), bind: { element in
-                    Binding(initial: element, bind: { _ in
+                    Binding(initial: { element }, bind: { _ in
                         NotificationContext<String,Notification>(name: .incrementedDemo)
                     }, update: { _, _, element in
                         self.number += 1

--- a/Sources/Binding.swift
+++ b/Sources/Binding.swift
@@ -40,17 +40,15 @@ public final class Binding<Element>
     }
     
     public init<Context:BindingContext>(
-        initial provider : () -> Element,
+        initial element : Element,
         bind bindingContext : (Element) -> Context,
         update updateElement : @escaping (Context, Context.Update, inout Element) -> ()
         )
     {
-        let element = provider()
-        
         self.element = element
         self.state = .initializing
         
-        let context = bindingContext(element)
+        let context = bindingContext(self.element)
         
         context.didUpdate = { [weak self] (update : Context.Update) -> () in
             self?.contextUpdated(with: update)

--- a/Sources/Binding.swift
+++ b/Sources/Binding.swift
@@ -40,13 +40,14 @@ public final class Binding<Element>
     }
     
     public init<Context:BindingContext>(
-        initial element : Element,
+        initial provider : () -> Element,
         bind bindingContext : (Element) -> Context,
         update updateElement : @escaping (Context, Context.Update, inout Element) -> ()
         )
     {
-        self.element = element
         self.state = .initializing
+        
+        self.element = provider()
         
         let context = bindingContext(self.element)
         

--- a/Sources/Binding.swift
+++ b/Sources/Binding.swift
@@ -85,8 +85,6 @@ public final class Binding<Element>
         case .initializing, .updating, .discarded: break
             
         case .new(let new):
-            new.context.bindAny(to: self)
-            
             self.state = .updating(
                 .init(
                     context: new.context,
@@ -94,6 +92,8 @@ public final class Binding<Element>
                     onChange: nil
                 )
             )
+            
+            new.context.anyBind(to: self)
         }
     }
     
@@ -103,10 +103,9 @@ public final class Binding<Element>
         case .initializing, .new, .discarded: break
             
         case .updating(let state):
-            state.context.unbindAny(from: self)
+            self.state = .discarded
+            state.context.anyUnbind(from: self)
         }
-        
-        self.state = .discarded
     }
     
     private func contextUpdated(with update: Any)
@@ -126,8 +125,10 @@ public final class Binding<Element>
 
 public protocol AnyBindingContext : AnyObject
 {
-    func bindAny<AnyElement>(to binding : Binding<AnyElement>)
-    func unbindAny<AnyElement>(from binding : Binding<AnyElement>)
+    func anyBind<AnyElement>(to binding : Binding<AnyElement>)
+    func anyFetchLatestUpdate<AnyUpdate>() -> AnyUpdate
+    
+    func anyUnbind<AnyElement>(from binding : Binding<AnyElement>)
 }
 
 
@@ -143,6 +144,8 @@ public protocol BindingContext : AnyBindingContext
     var didUpdate : DidUpdate? { get set }
     
     func bind(to binding : Binding<Element>)
+    func fetchLatestUpdate() -> Update
+    
     func unbind(from binding : Binding<Element>)
 }
 
@@ -150,14 +153,20 @@ public extension BindingContext
 {
     // MARK: AnyBindingContext
     
-    func bindAny<AnyElement>(to binding : Binding<AnyElement>)
+    func anyBind<AnyElement>(to binding : Binding<AnyElement>)
     {
         let binding = binding as! Binding<Element>
         
         self.bind(to: binding)
     }
     
-    func unbindAny<AnyElement>(from binding : Binding<AnyElement>)
+    func anyFetchLatestUpdate<AnyUpdate>() -> AnyUpdate
+    {
+        // TODO
+        fatalError()
+    }
+    
+    func anyUnbind<AnyElement>(from binding : Binding<AnyElement>)
     {
         let binding = binding as! Binding<Element>
         
@@ -204,6 +213,12 @@ public final class NotificationContext<Element, Update> : BindingContext
     public func bind(to binding: Binding<Element>)
     {
         self.center.addObserver(self, selector: #selector(recievedNotification(_:)), name: self.name, object: self.object)
+    }
+    
+    // TODO Implement me...
+    public func fetchLatestUpdate() -> Update
+    {
+        fatalError()
     }
     
     public func unbind(from binding : Binding<Element>)

--- a/Sources/Binding.swift
+++ b/Sources/Binding.swift
@@ -94,6 +94,8 @@ public final class Binding<Element>
             )
             
             new.context.anyBind(to: self)
+            
+            new.context.fetchAndPushLatestUpdate()
         }
     }
     
@@ -126,7 +128,7 @@ public final class Binding<Element>
 public protocol AnyBindingContext : AnyObject
 {
     func anyBind<AnyElement>(to binding : Binding<AnyElement>)
-    func anyFetchLatestUpdate<AnyUpdate>() -> AnyUpdate
+    func fetchAndPushLatestUpdate()
     
     func anyUnbind<AnyElement>(from binding : Binding<AnyElement>)
 }
@@ -160,10 +162,11 @@ public extension BindingContext
         self.bind(to: binding)
     }
     
-    func anyFetchLatestUpdate<AnyUpdate>() -> AnyUpdate
+    func fetchAndPushLatestUpdate()
     {
-        // TODO
-        fatalError()
+        let latest = self.fetchLatestUpdate()
+        
+        self.didUpdate?(latest)
     }
     
     func anyUnbind<AnyElement>(from binding : Binding<AnyElement>)

--- a/Sources/Diff.swift
+++ b/Sources/Diff.swift
@@ -966,7 +966,7 @@ private final class DiffableCollection<Value>
     
     private func resetIndexLookups()
     {
-        self.identifierContainerIndexes.removeAll()
+        self.identifierContainerIndexes.removeAll(keepingCapacity: true)
     }
     
     private func generateIndexLookupsIfNeeded()

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -12,23 +12,29 @@ public final class AnyIdentifier : Hashable
 {
     private let value : AnyHashable
     
+    private let hash : Int
+    
     public init<Element>(_ value : Identifier<Element>)
     {
         self.value = AnyHashable(value)
+        
+        var hasher = Hasher()
+        hasher.combine(self.value)
+        self.hash = hasher.finalize()
     }
     
     // Equatable
     
     public static func == (lhs: AnyIdentifier, rhs: AnyIdentifier) -> Bool
     {
-        return lhs.value == rhs.value
+        return lhs.hash == rhs.hash && lhs.value == rhs.value
     }
     
     // Hashable
     
     public func hash(into hasher: inout Hasher)
     {
-        hasher.combine(self.value)
+        hasher.combine(self.hash)
     }
 }
 
@@ -37,25 +43,31 @@ public final class Identifier<Element> : Hashable
     private let type : ObjectIdentifier
     private let value : AnyHashable
     
+    private let hash : Int
+    
     public init<Value:Hashable>(_ value : Value)
     {
         self.value = AnyHashable(value)
         self.type = ObjectIdentifier(Element.self)
+        
+        var hasher = Hasher()
+        hasher.combine(self.type)
+        hasher.combine(self.value)
+        self.hash = hasher.finalize()
     }
     
     // Equatable
     
     public static func == (lhs: Identifier<Element>, rhs: Identifier<Element>) -> Bool
     {
-        return lhs.type == rhs.type && lhs.value == rhs.value
+        return lhs.hash == rhs.hash && lhs.type == rhs.type && lhs.value == rhs.value
     }
     
     // Hashable
     
     public func hash(into hasher: inout Hasher)
     {
-        hasher.combine(self.type)
-        hasher.combine(self.value)
+        hasher.combine(self.hash)
     }
 }
 

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-public struct AnyIdentifier : Hashable
+public final class AnyIdentifier : Hashable
 {
     private let value : AnyHashable
     
@@ -16,17 +16,46 @@ public struct AnyIdentifier : Hashable
     {
         self.value = AnyHashable(value)
     }
+    
+    // Equatable
+    
+    public static func == (lhs: AnyIdentifier, rhs: AnyIdentifier) -> Bool
+    {
+        return lhs.value == rhs.value
+    }
+    
+    // Hashable
+    
+    public func hash(into hasher: inout Hasher)
+    {
+        hasher.combine(self.value)
+    }
 }
 
-public struct Identifier<Element> : Hashable
+public final class Identifier<Element> : Hashable
 {
-    private let value : AnyHashable
     private let type : ObjectIdentifier
+    private let value : AnyHashable
     
     public init<Value:Hashable>(_ value : Value)
     {
         self.value = AnyHashable(value)
         self.type = ObjectIdentifier(Element.self)
+    }
+    
+    // Equatable
+    
+    public static func == (lhs: Identifier<Element>, rhs: Identifier<Element>) -> Bool
+    {
+        return lhs.type == rhs.type && lhs.value == rhs.value
+    }
+    
+    // Hashable
+    
+    public func hash(into hasher: inout Hasher)
+    {
+        hasher.combine(self.type)
+        hasher.combine(self.value)
     }
 }
 

--- a/Sources/TableView/Content.swift
+++ b/Sources/TableView/Content.swift
@@ -581,6 +581,8 @@ public extension TableView
         
         struct Slice
         {
+            static let defaultSize : Int = 250
+            
             let truncatedBottom : Bool
             let content : Content
             
@@ -605,8 +607,12 @@ public extension TableView
                 
                 case contentChanged(animated : Bool)
                 
-                // TODO: Remove
                 var diffsChanges : Bool {
+                    /*
+                     We only diff in the case of content change to avoid visual artifacts in the table view;
+                     even with no animation type provided to batch update methods, the table view still moves
+                     rows around in an animated manner.
+                     */
                     switch self {
                     case .scrolledDown: return false
                     case .didEndDecelerating: return false

--- a/Sources/TableView/Content.swift
+++ b/Sources/TableView/Content.swift
@@ -581,7 +581,7 @@ public extension TableView
         
         struct Slice
         {
-            static let defaultSize : Int = 250
+            static let defaultSize : Int = 1000
             
             let truncatedBottom : Bool
             let content : Content

--- a/Sources/TableView/TableView.PresentationState.swift
+++ b/Sources/TableView/TableView.PresentationState.swift
@@ -102,6 +102,11 @@ internal extension TableView
                             self.row.element.applyTo(cell: cell, reason: .willDisplay)
                         }
                     }
+                    
+                    // Pull the current element off the binding in case it changed
+                    // during initialization, from the provider.
+                    
+                    self.row.element = binding.element
                 }
             }
             

--- a/Sources/TableView/TableView.PresentationState.swift
+++ b/Sources/TableView/TableView.PresentationState.swift
@@ -94,7 +94,6 @@ internal extension TableView
                     binding.start()
 
                     binding.onChange { [weak self] element in
-                        
                         guard let self = self else { return }
                         
                         self.row.element = element
@@ -111,10 +110,6 @@ internal extension TableView
             }
             
             // MARK: TableViewPresentationStateRow
-            
-            public var anyRow: TableViewRow {
-                return self.row
-            }
             
             public func update(with old : TableViewRow, new : TableViewRow)
             {

--- a/Sources/TableView/TableView.swift
+++ b/Sources/TableView/TableView.swift
@@ -51,7 +51,8 @@ public final class TableView : UIView
     public func set(content new : Content, animated : Bool = false)
     {
         let old = self.content
-        self._content = new
+    
+        _content = new
         
         let diff = TableView.diffWith(old: old, new: new)
         


### PR DESCRIPTION
Since bindings may not be allocated and begin listening at all times (the content of the table view is faulted as you scroll to vastly improve performance in the case that the user never scrolls), instead, change the binding initializer to give the option of providing an updated element value.