### PR TITLE
Un-nest all types from under TableView

### DIFF
--- a/Demo/Sources/DemosRootViewController.swift
+++ b/Demo/Sources/DemosRootViewController.swift
@@ -28,9 +28,9 @@ public final class DemosRootViewController : UIViewController
         self.view = self.tableView
         
         self.tableView.setContent { table in
-            table += TableView.Section(header: "Table Views") { rows in
+            table += Section(header: "Table Views") { rows in
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text:"English Dictionary Search",
                         detail: "Shows the Websters English dictionary, sectioned by letter."
@@ -39,7 +39,7 @@ public final class DemosRootViewController : UIViewController
                         self.push(TableViewDemosDictionaryViewController())
                 })
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text: "Random Sorter",
                         detail: "Randomly resorts the content, with animation."),
@@ -47,7 +47,7 @@ public final class DemosRootViewController : UIViewController
                         self.push(TableViewDemosRandomResortViewController())
                 })
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text: "Lorem Ipsum",
                         detail: "Headers, footers, and cells showing varying amounts of ipsum to demonstrate sizing."),
@@ -55,7 +55,7 @@ public final class DemosRootViewController : UIViewController
                         self.push(TableViewDemosIpsumViewController())
                 })
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text: "Bindings Demo",
                         detail: "Shows how bindings work on table view cell."),
@@ -63,7 +63,7 @@ public final class DemosRootViewController : UIViewController
                         self.push(TableViewDemosBindingsViewController())
                 })
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text: "SPOS Items List",
                         detail: "Example of what the items library looks like in SPOS."),
@@ -71,7 +71,7 @@ public final class DemosRootViewController : UIViewController
                         self.push(TableViewDemosSPOSItemsListViewController())
                 })
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text: "Transaction History",
                         detail: "Example of what the transaction list looks like in SPOS, including load on scroll and pull to refresh."),
@@ -79,7 +79,7 @@ public final class DemosRootViewController : UIViewController
                         self.push(TableViewDemosSPOSTransactionsListViewController())
                 })
                 
-                rows += TableView.Row(
+                rows += Row(
                     SubtitleRow(
                         text: "Cart",
                         detail: "Example of the cart view in Point of Sale."),
@@ -88,8 +88,8 @@ public final class DemosRootViewController : UIViewController
                 })
             }
             
-            table += TableView.Section(header: "Collection Views") { rows in
-                rows += TableView.Row(
+            table += Section(header: "Collection Views") { rows in
+                rows += Row(
                     SubtitleRow(
                         text: "Flow Layout",
                         detail: "Demo of flow layout wrapper."

--- a/Demo/Sources/TableView/TableViewDemosBindingsViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosBindingsViewController.swift
@@ -30,8 +30,8 @@ final class TableViewDemosBindingsViewController : UIViewController
         self.view = self.tableView
         
         self.tableView.setContent { table in
-            table += TableView.Section(header: "Demo Section") { rows in
-                rows += TableView.Row(String(self.number), bind: { element in
+            table += Section(header: "Demo Section") { rows in
+                rows += Row(String(self.number), bind: { element in
                     Binding(initial: { element }, bind: { _ in
                         NotificationContext<String,Notification>(name: .incrementedDemo)
                     }, update: { _, _, element in

--- a/Demo/Sources/TableView/TableViewDemosCartViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosCartViewController.swift
@@ -38,13 +38,13 @@ final class TableViewDemosCartViewController : UIViewController
             }
         }
         
-        func content(with state: SourceState<State>, table: inout TableView.ContentBuilder)
+        func content(with state: SourceState<State>, table: inout ContentBuilder)
         {
             guard self.itemizations.isEmpty == false else {
                 return
             }
             
-            table += TableView.Section(identifier: "search") { rows in
+            table += Section(identifier: "search") { rows in
                 self.searchRow.view.onStateChanged = { filter in
                     state.value.filter = filter
                 }
@@ -52,7 +52,7 @@ final class TableViewDemosCartViewController : UIViewController
                 rows += self.searchRow
             }
             
-            table += TableView.Section(identifier: "itemizations") { rows in
+            table += Section(identifier: "itemizations") { rows in
                 
                 rows += self.itemizations.compactMap { itemization in
                     
@@ -60,13 +60,13 @@ final class TableViewDemosCartViewController : UIViewController
                         return nil
                     }
                     
-                    return TableView.Row(
+                    return Row(
                         ItemizationRow(itemization: itemization),
                         
                         sizing: .thatFits(.noConstraint),
                         
-                        trailingActions: TableView.SwipeActions(
-                            TableView.SwipeAction(
+                        trailingActions: SwipeActions(
+                            SwipeAction(
                                 title: "Delete",
                                 style: .destructive,
                                 onTap: { _ in
@@ -80,11 +80,11 @@ final class TableViewDemosCartViewController : UIViewController
                 }
             }
             
-            table += TableView.Section(identifier: "amounts") { rows in
-                rows += TableView.Row(AmountRow(title: "Tax", detail: "$1.50"))
-                rows += TableView.Row(AmountRow(title: "Discount", detail: "$2.00"))
-                rows += TableView.Row(AmountRow(title: "Loyalty", detail: "No Points"))
-                rows += TableView.Row(AmountRow(title: "Total", detail: "$10.00"))
+            table += Section(identifier: "amounts") { rows in
+                rows += Row(AmountRow(title: "Tax", detail: "$1.50"))
+                rows += Row(AmountRow(title: "Discount", detail: "$2.00"))
+                rows += Row(AmountRow(title: "Loyalty", detail: "No Points"))
+                rows += Row(AmountRow(title: "Total", detail: "$10.00"))
             }
         }
     }

--- a/Demo/Sources/TableView/TableViewDemosDictionaryViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosDictionaryViewController.swift
@@ -41,7 +41,7 @@ final public class TableViewDemosDictionaryViewController : UIViewController
             }
         }
 
-        func content(with state: SourceState<State>, table: inout TableView.ContentBuilder)
+        func content(with state: SourceState<State>, table: inout ContentBuilder)
         {
             if #available(iOS 10.0, *) {
                 table.refreshControl = RefreshControl() { finished in
@@ -51,7 +51,7 @@ final public class TableViewDemosDictionaryViewController : UIViewController
                 }
             }
             
-            table += TableView.Section(identifier: "Search") { rows in
+            table += Section(identifier: "Search") { rows in
                 self.searchRow.view.onStateChanged = { filter in
                     state.value.filter = filter
                 }
@@ -63,12 +63,12 @@ final public class TableViewDemosDictionaryViewController : UIViewController
             
             table += self.dictionary.wordsByLetter.map { letter in
                 
-                return TableView.Section(header: letter.letter) { rows in
+                return Section(header: letter.letter) { rows in
                     
                     rows += letter.words.compactMap { word in
                         if state.value.include(word.word) {
                             hasContent = true
-                            return TableView.Row(SubtitleRow(text: word.word, detail: word.description))
+                            return Row(SubtitleRow(text: word.word, detail: word.description))
                         } else {
                             return nil
                         }
@@ -79,8 +79,8 @@ final public class TableViewDemosDictionaryViewController : UIViewController
             table.removeEmpty()
             
             if hasContent == false {
-                table += TableView.Section(identifier: "emptty") { rows in
-                    rows += TableView.Row(
+                table += Section(identifier: "emptty") { rows in
+                    rows += Row(
                         SubtitleRow(
                             text: "No Results For '\(state.value.filter)'",
                             detail: "Please enter a different search."

--- a/Demo/Sources/TableView/TableViewDemosIpsumViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosIpsumViewController.swift
@@ -21,18 +21,18 @@ final public class TableViewDemosIpsumViewController : UIViewController
         
         self.tableView.setContent(animated:false) { content in
             
-            content += TableView.Section(
-                header: TableView.HeaderFooter(ipsum, sizing: .thatFits(.noConstraint)),
-                footer: TableView.HeaderFooter("This is a footer!", sizing: .thatFits(.noConstraint))
+            content += Section(
+                header: HeaderFooter(ipsum, sizing: .thatFits(.noConstraint)),
+                footer: HeaderFooter("This is a footer!", sizing: .thatFits(.noConstraint))
             ) {
                 $0 += "Row 1"
                 $0 += "Row 2"
-                $0 += TableView.Row("Short row", sizing: .thatFits(.noConstraint))
-                $0 += TableView.Row(ipsum, sizing: .thatFits(.noConstraint))
+                $0 += Row("Short row", sizing: .thatFits(.noConstraint))
+                $0 += Row(ipsum, sizing: .thatFits(.noConstraint))
                 $0 += ipsum
             }
             
-            content += TableView.Section(header: TableView.HeaderFooter("Section 0.5")) { rows in
+            content += Section(header: HeaderFooter("Section 0.5")) { rows in
                 rows += [
                     "1",
                     "2",
@@ -40,7 +40,7 @@ final public class TableViewDemosIpsumViewController : UIViewController
                 ]
             }
             
-            content += TableView.Section(header: TableView.HeaderFooter("Section 1")) { rows in
+            content += Section(header: HeaderFooter("Section 1")) { rows in
                 
                 rows += "Row 1"
                 rows += "Row 2"
@@ -49,10 +49,10 @@ final public class TableViewDemosIpsumViewController : UIViewController
                 rows += .init("Row 4")
             }
             
-            content += TableView.Section(header: TableView.HeaderFooter("Section 2")) { rows in
-                rows += TableView.Row("Row 1")
-                rows += TableView.Row("Row 2")
-                rows += TableView.Row("Row 3")
+            content += Section(header: HeaderFooter("Section 2")) { rows in
+                rows += Row("Row 1")
+                rows += Row("Row 2")
+                rows += Row("Row 3")
             }
         }
     }

--- a/Demo/Sources/TableView/TableViewDemosRandomResortViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosRandomResortViewController.swift
@@ -56,13 +56,13 @@ final class TableViewDemosRandomResortViewController : UIViewController
         
         struct State : Equatable {}
         
-        func content(with state: SourceState<State>, table: inout TableView.ContentBuilder)
+        func content(with state: SourceState<State>, table: inout ContentBuilder)
         {
             (1...5).forEach { sectionIndex in
-                table += TableView.Section(identifier: sectionIndex, header: TableView.HeaderFooter(String(sectionIndex))) { rows in
+                table += Section(identifier: sectionIndex, header: HeaderFooter(String(sectionIndex))) { rows in
                     
                     (1...10).forEach { rowIndex in
-                        rows += TableView.Row(String(rowIndex))
+                        rows += Row(String(rowIndex))
                     }
                     
                     rows.rows.shuffle(using: &self.rng)

--- a/Demo/Sources/TableView/TableViewDemosSPOSItemsListViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosSPOSItemsListViewController.swift
@@ -36,9 +36,9 @@ final class TableViewDemosSPOSItemsListViewController : UIViewController
             }
         }
         
-        func content(with state: SourceState<State>, table: inout TableView.ContentBuilder)
+        func content(with state: SourceState<State>, table: inout ContentBuilder)
         {
-            table += TableView.Section(identifier: "Search") { rows in
+            table += Section(identifier: "Search") { rows in
                 self.searchRow.view.onStateChanged = { filter in
                     state.value.filter = filter
                 }
@@ -46,7 +46,7 @@ final class TableViewDemosSPOSItemsListViewController : UIViewController
                 rows += self.searchRow
             }
             
-            table += TableView.Section(identifier: "actions") { rows in
+            table += Section(identifier: "actions") { rows in
                 rows += Product(
                     tile: Tile(
                         abbreviation: .init(color: .darkGray, text: "$"),
@@ -81,7 +81,7 @@ final class TableViewDemosSPOSItemsListViewController : UIViewController
             let letters = EnglishDictionary.dictionary.wordsByLetter
             
             letters.forEach { letter in
-                table += TableView.Section(header: letter.letter.capitalized) { rows in
+                table += Section(header: letter.letter.capitalized) { rows in
                     
                     letter.words[0...50].forEach { word in
                         

--- a/Demo/Sources/TableView/TableViewDemosSPOSTransactionsListViewController.swift
+++ b/Demo/Sources/TableView/TableViewDemosSPOSTransactionsListViewController.swift
@@ -40,38 +40,38 @@ final class TableViewDemosSPOSTransactionsListViewController : UIViewController
             }
         }
         
-        func content(with state: SourceState<State>, table: inout TableView.ContentBuilder)
+        func content(with state: SourceState<State>, table: inout ContentBuilder)
         {
             switch state.value.content {
             case .new: break
                 
             case .loading(_):
-                table += TableView.Section(identifier: "loading") { rows in
-                    rows += TableView.Row("Loading...")
+                table += Section(identifier: "loading") { rows in
+                    rows += Row("Loading...")
                 }
                 
             case .content(let content):
-                table += TableView.Section(header: "Payments") { rows in
+                table += Section(header: "Payments") { rows in
                     
                     rows += content.transactions.map { transaction in
-                        TableView.Row(transaction.remoteID.uuidString)
+                        Row(transaction.remoteID.uuidString)
                     }
                     
                     if content.hasMore {
-                        rows += TableView.Row("Load More", onDisplay: { _ in
+                        rows += Row("Load More", onDisplay: { _ in
                             
                         })
                     }
                 }
                 
             case .error:
-                table += TableView.Section(identifier: "error") { rows in
-                    rows += TableView.Row("Error!")
+                table += Section(identifier: "error") { rows in
+                    rows += Row("Error!")
                 }
                 
             case .empty:
-                table += TableView.Section(identifier: "empty") { rows in
-                    rows += TableView.Row("No Payments")
+                table += Section(identifier: "empty") { rows in
+                    rows += Row("No Payments")
                 }
             }
         }

--- a/ListableTableView/Sources/Builders.swift
+++ b/ListableTableView/Sources/Builders.swift
@@ -8,99 +8,96 @@
 import ListableCore
 
 
-public extension TableView
-{    
-    struct ContentBuilder
+public struct ContentBuilder
+{
+    public typealias Build = (inout ContentBuilder) -> ()
+    
+    public static func build(with block : Build) -> Content
     {
-        public typealias Build = (inout ContentBuilder) -> ()
-        
-        public static func build(with block : Build) -> Content
-        {
-            var builder = ContentBuilder()
-            block(&builder)
-            return builder.content
-        }
-        
-        public var content : TableView.Content {
-            return TableView.Content(
-                refreshControl: self.refreshControl,
-                header: self.header,
-                footer: self.footer,
-                sections: self.sections
-            )
-        }
-        
-        public var refreshControl : RefreshControl?
-        
-        public var header : TableViewHeaderFooter?
-        public var footer : TableViewHeaderFooter?
-        
-        public var sections : [TableView.Section] = []
-        
-        public var isEmpty : Bool {
-            return self.sections.firstIndex { $0.rows.isEmpty == false } == nil
-        }
-        
-        public mutating func removeEmpty()
-        {
-            self.sections.removeAll {
-                $0.rows.isEmpty
-            }
-        }
-
-        public static func += (lhs : inout ContentBuilder, rhs : TableView.Section)
-        {
-            lhs.sections.append(rhs)
-        }
-        
-        public static func += (lhs : inout ContentBuilder, rhs : [TableView.Section])
-        {
-            lhs.sections += rhs
+        var builder = ContentBuilder()
+        block(&builder)
+        return builder.content
+    }
+    
+    public var content : Content {
+        return Content(
+            refreshControl: self.refreshControl,
+            header: self.header,
+            footer: self.footer,
+            sections: self.sections
+        )
+    }
+    
+    public var refreshControl : RefreshControl?
+    
+    public var header : TableViewHeaderFooter?
+    public var footer : TableViewHeaderFooter?
+    
+    public var sections : [Section] = []
+    
+    public var isEmpty : Bool {
+        return self.sections.firstIndex { $0.rows.isEmpty == false } == nil
+    }
+    
+    public mutating func removeEmpty()
+    {
+        self.sections.removeAll {
+            $0.rows.isEmpty
         }
     }
     
-    struct SectionBuilder
+    public static func += (lhs : inout ContentBuilder, rhs : Section)
     {
-        public var rows : [TableViewRow] = []
+        lhs.sections.append(rhs)
+    }
+    
+    public static func += (lhs : inout ContentBuilder, rhs : [Section])
+    {
+        lhs.sections += rhs
+    }
+}
+
+public struct SectionBuilder
+{
+    public var rows : [TableViewRow] = []
+    
+    public var isEmpty : Bool {
+        return self.rows.isEmpty
+    }
+    
+    // Adds the given row to the builder.
+    public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : Row<Element>)
+    {
+        lhs.rows.append(rhs)
+    }
+    
+    // Converts `Element` which conforms to `TableViewElement` into Rows.
+    public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : Element)
+    {
+        let row = Row(rhs)
         
-        public var isEmpty : Bool {
-            return self.rows.isEmpty
+        lhs.rows.append(row)
+    }
+    
+    // Allows mixed arrays of different types of rows.
+    public static func += (lhs : inout SectionBuilder, rhs : [TableViewRow])
+    {
+        lhs.rows += rhs
+    }
+    
+    // Arrays of the same type of rows – allows `[.init(...)]` syntax within the array.
+    public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : [Row<Element>])
+    {
+        lhs.rows += rhs
+    }
+    
+    // Converts `Element` which conforms to `TableViewRowValue` into Rows.
+    public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : [Element])
+    {
+        let rows = rhs.map {
+            Row($0)
         }
         
-        // Adds the given row to the builder.
-        public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : TableView.Row<Element>)
-        {
-            lhs.rows.append(rhs)
-        }
-        
-        // Converts `Element` which conforms to `TableViewElement` into Rows.
-        public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : Element)
-        {
-            let row = TableView.Row(rhs)
-            
-            lhs.rows.append(row)
-        }
-        
-        // Allows mixed arrays of different types of rows.
-        public static func += (lhs : inout SectionBuilder, rhs : [TableViewRow])
-        {
-            lhs.rows += rhs
-        }
-        
-        // Arrays of the same type of rows – allows `[.init(...)]` syntax within the array.
-        public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : [TableView.Row<Element>])
-        {
-            lhs.rows += rhs
-        }
-        
-        // Converts `Element` which conforms to `TableViewRowValue` into Rows.
-        public static func += <Element:TableViewRowElement>(lhs : inout SectionBuilder, rhs : [Element])
-        {
-            let rows = rhs.map {
-                TableView.Row($0)
-            }
-            
-            lhs.rows += rows
-        }
+        lhs.rows += rows
     }
 }

--- a/ListableTableView/Sources/Content.swift
+++ b/ListableTableView/Sources/Content.swift
@@ -46,345 +46,345 @@ public protocol TableViewRow_Internal
     func movedComparedTo(old : TableViewRow) -> Bool
     
     @available(iOS 11.0, *)
-    func leadingSwipeActionsConfiguration(onPerform : @escaping TableView.SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
+    func leadingSwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
 
     @available(iOS 11.0, *)
-    func trailingSwipeActionsConfiguration(onPerform : @escaping TableView.SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
+    func trailingSwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
     
-    func trailingTableViewRowActions(onPerform : @escaping TableView.SwipeAction.OnPerform) -> [UITableViewRowAction]?
+    func trailingTableViewRowActions(onPerform : @escaping SwipeAction.OnPerform) -> [UITableViewRowAction]?
     
-    func newPresentationRow() -> TableViewPresentationStateRow
+    func newPresentationContainer() -> PresentationStateRowState
 }
 
-public extension TableView
-{    
-    struct Section
+public struct Section
+{
+    public let identifier : AnyHashable
+    
+    public var header : TableViewHeaderFooter?
+    public var footer : TableViewHeaderFooter?
+    
+    public var rows : [TableViewRow]
+    
+    public init(
+        header headerString: String,
+        footer footerString: String? = nil,
+        content contentBuilder : (inout SectionBuilder) -> ()
+        )
     {
-        public let identifier : AnyHashable
+        var builder = SectionBuilder()
         
-        public var header : TableViewHeaderFooter?
-        public var footer : TableViewHeaderFooter?
+        contentBuilder(&builder)
         
-        public var rows : [TableViewRow]
+        var footer : TableViewHeaderFooter?
         
-        public init(
-            header headerString: String,
-            footer footerString: String? = nil,
-            content contentBuilder : (inout SectionBuilder) -> ()
-            )
-        {
-            var builder = SectionBuilder()
-            
-            contentBuilder(&builder)
-            
-            var footer : TableViewHeaderFooter?
-            
-            if let footerString = footerString {
-                footer = TableView.HeaderFooter(footerString)
-            }
-            
-            self.init(
-                identifier: footerString,
-                header: TableView.HeaderFooter(headerString),
-                footer: footer,
-                rows: builder.rows
-            )
+        if let footerString = footerString {
+            footer = HeaderFooter(footerString)
         }
         
-        public init<Identifier:Hashable>(
-            identifier : Identifier,
-            header : TableViewHeaderFooter? = nil,
-            footer : TableViewHeaderFooter? = nil,
-            content contentBuilder : (inout SectionBuilder) -> ()
-            )
-        {
-            var builder = SectionBuilder()
-            
-            contentBuilder(&builder)
-            
-            self.init(
-                identifier: identifier,
-                header: header,
-                footer: footer,
-                rows: builder.rows
-            )
-        }
-        
-        public init<Header:TableViewHeaderFooterElement>(
-            header : TableView.HeaderFooter<Header>,
-            footer : TableViewHeaderFooter? = nil,
-            content contentBuilder : (inout SectionBuilder) -> ()
-            )
-        {
-            var builder = SectionBuilder()
-            
-            contentBuilder(&builder)
-            
-            self.init(
-                identifier: header.element.identifier,
-                header: header,
-                footer: footer,
-                rows: builder.rows
-            )
-        }
-        
-        public init<Identifier:Hashable>(
-            identifier : Identifier,
-            header : TableViewHeaderFooter? = nil,
-            footer : TableViewHeaderFooter? = nil,
-            rows : [TableViewRow] = []
-            )
-        {
-            self.identifier = AnyHashable(identifier)
-            
-            self.header = header
-            self.footer = footer
-            
-            self.rows = rows
-        }
-        
-        // MARK: TableViewSection
-        
-        public func updatedComparedTo(old : TableView.Section) -> Bool
-        {
-            let headerChanged = TableView.headerFooterChanged(self.header, old.header, { $0.updatedComparedTo(old: $1) })
-            let footerChanged = TableView.headerFooterChanged(self.footer, old.footer, { $0.updatedComparedTo(old: $1) })
-            
-            return headerChanged || footerChanged
-        }
-        
-        public func movedComparedTo(old : TableView.Section) -> Bool
-        {
-            let headerChanged = TableView.headerFooterChanged(self.header, old.header, { $0.movedComparedTo(old: $1) })
-            let footerChanged = TableView.headerFooterChanged(self.footer, old.footer, { $0.movedComparedTo(old: $1) })
-            
-            return headerChanged || footerChanged
-        }
-        
-        // MARK: Slicing
-        
-        func rowsUpTo(limit : Int) -> [TableViewRow]
-        {
-            let end = min(self.rows.count, limit)
-            
-            return Array(self.rows[0..<end])
-        }
+        self.init(
+            identifier: footerString,
+            header: HeaderFooter(headerString),
+            footer: footer,
+            rows: builder.rows
+        )
     }
     
-    
-    struct HeaderFooter<Element:TableViewHeaderFooterElement> : TableViewHeaderFooter
+    public init<Identifier:Hashable>(
+        identifier : Identifier,
+        header : TableViewHeaderFooter? = nil,
+        footer : TableViewHeaderFooter? = nil,
+        content contentBuilder : (inout SectionBuilder) -> ()
+        )
     {
-        public var element : Element
-        public var sizing : AxisSizing
+        var builder = SectionBuilder()
         
-        private let reuseIdentifier : ReuseIdentifier<Element>
+        contentBuilder(&builder)
         
-        // MARK: Initialization
+        self.init(
+            identifier: identifier,
+            header: header,
+            footer: footer,
+            rows: builder.rows
+        )
+    }
+    
+    public init<Header:TableViewHeaderFooterElement>(
+        header : HeaderFooter<Header>,
+        footer : TableViewHeaderFooter? = nil,
+        content contentBuilder : (inout SectionBuilder) -> ()
+        )
+    {
+        var builder = SectionBuilder()
         
-        public init(_ element : Element, sizing : AxisSizing = .default)
-        {
-            self.element = element
-            self.sizing = sizing
-            
-            self.reuseIdentifier = ReuseIdentifier.identifier(for: self.element)
-        }
+        contentBuilder(&builder)
         
-        // MARK: TableViewHeaderFooter
+        self.init(
+            identifier: header.element.identifier,
+            header: header,
+            footer: footer,
+            rows: builder.rows
+        )
+    }
+    
+    public init<Identifier:Hashable>(
+        identifier : Identifier,
+        header : TableViewHeaderFooter? = nil,
+        footer : TableViewHeaderFooter? = nil,
+        rows : [TableViewRow] = []
+        )
+    {
+        self.identifier = AnyHashable(identifier)
         
-        public func heightWith(width : CGFloat, default defaultHeight : CGFloat, measurementCache : ReusableViewCache) -> CGFloat
-        {
-            return measurementCache.use(with: self.reuseIdentifier, create: { Element.createReusableHeaderFooterView(with: self.reuseIdentifier) }) { view in
-                self.element.apply(to: view, reason: .willDisplay)
-                
-                return self.sizing.height(with: view, fittingWidth: width, default: defaultHeight)
-            }
-        }
+        self.header = header
+        self.footer = footer
         
-        public func applyTo(headerFooterView : UITableViewHeaderFooterView, reason : ApplyReason)
-        {
-            guard let view = headerFooterView as? Element.HeaderFooterView else {
-                return
-            }
-            
-            self.element.apply(to: view, reason: reason)
-        }
+        self.rows = rows
+    }
+    
+    // MARK: TableViewSection
+    
+    public func updatedComparedTo(old : Section) -> Bool
+    {
+        let headerChanged = TableView.headerFooterChanged(self.header, old.header, { $0.updatedComparedTo(old: $1) })
+        let footerChanged = TableView.headerFooterChanged(self.footer, old.footer, { $0.updatedComparedTo(old: $1) })
         
-        public func dequeueView(in tableView: UITableView) -> UITableViewHeaderFooterView
-        {
-            let view : Element.HeaderFooterView = {
-                if let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: self.reuseIdentifier.stringValue) {
-                    return view as! Element.HeaderFooterView
-                } else {
-                    return Element.createReusableHeaderFooterView(with: self.reuseIdentifier)
-                }
-            }()
-            
+        return headerChanged || footerChanged
+    }
+    
+    public func movedComparedTo(old : Section) -> Bool
+    {
+        let headerChanged = TableView.headerFooterChanged(self.header, old.header, { $0.movedComparedTo(old: $1) })
+        let footerChanged = TableView.headerFooterChanged(self.footer, old.footer, { $0.movedComparedTo(old: $1) })
+        
+        return headerChanged || footerChanged
+    }
+    
+    // MARK: Slicing
+    
+    func rowsUpTo(limit : Int) -> [TableViewRow]
+    {
+        let end = min(self.rows.count, limit)
+        
+        return Array(self.rows[0..<end])
+    }
+}
+
+
+public struct HeaderFooter<Element:TableViewHeaderFooterElement> : TableViewHeaderFooter
+{
+    public var element : Element
+    public var sizing : AxisSizing
+    
+    private let reuseIdentifier : ReuseIdentifier<Element>
+    
+    // MARK: Initialization
+    
+    public init(_ element : Element, sizing : AxisSizing = .default)
+    {
+        self.element = element
+        self.sizing = sizing
+        
+        self.reuseIdentifier = ReuseIdentifier.identifier(for: self.element)
+    }
+    
+    // MARK: TableViewHeaderFooter
+    
+    public func heightWith(width : CGFloat, default defaultHeight : CGFloat, measurementCache : ReusableViewCache) -> CGFloat
+    {
+        return measurementCache.use(with: self.reuseIdentifier, create: { Element.createReusableHeaderFooterView(with: self.reuseIdentifier) }) { view in
             self.element.apply(to: view, reason: .willDisplay)
             
-            return view
-        }
-        
-        public func updatedComparedTo(old : TableViewHeaderFooter) -> Bool
-        {
-            guard let old = old as? HeaderFooter<Element> else {
-                return true
-            }
-            
-            return self.element.wasUpdated(comparedTo: old.element)
-        }
-        
-        public func movedComparedTo(old : TableViewHeaderFooter) -> Bool
-        {
-            guard let old = old as? HeaderFooter<Element> else {
-                return true
-            }
-            
-            return self.element.wasMoved(comparedTo: old.element)
+            return self.sizing.height(with: view, fittingWidth: width, default: defaultHeight)
         }
     }
     
-    struct Row<Element:TableViewRowElement> : TableViewRow
+    public func applyTo(headerFooterView : UITableViewHeaderFooterView, reason : ApplyReason)
     {
-        public var identifier : AnyIdentifier
-        
-        public var element : Element
-        
-        public var sizing : AxisSizing
-        
-        public var configuration : CellConfiguration
-        
-        public var leadingActions : SwipeActions?
-        public var trailingActions : SwipeActions?
-        
-        public typealias OnTap = (Element) -> ()
-        public var onTap : OnTap?
-        
-        public typealias OnDisplay = (Element) -> ()
-        public var onDisplay : OnDisplay?
-        
-        private let reuseIdentifier : ReuseIdentifier<Element>
-        
-        public typealias CreateBinding = (Element) -> Binding<Element>
-        internal let bind : CreateBinding?
- 
-        public init(
-            _ element : Element,
-            sizing : AxisSizing = .default,
-            configuration : CellConfiguration = .default,
-            leadingActions : SwipeActions? = nil,
-            trailingActions : SwipeActions? = nil,
-            bind : CreateBinding? = nil,
-            onDisplay : OnDisplay? = nil,
-            onTap : OnTap? = nil
-            )
-        {
-            self.element = element
-            
-            self.reuseIdentifier = ReuseIdentifier.identifier(for: self.element)
-            
-            self.identifier = AnyIdentifier(element.identifier)
-            
-            self.sizing = sizing
-            
-            self.configuration = configuration
-            
-            self.leadingActions = leadingActions
-            self.trailingActions = trailingActions
-            
-            self.bind = bind
-            
-            self.onDisplay = onDisplay
-            
-            if onTap == nil {
-                self.configuration.selectionStyle = .none
-            }
-            
-            self.onTap = onTap
+        guard let view = headerFooterView as? Element.HeaderFooterView else {
+            return
         }
         
-        // MARK: TableViewRow
-        
-        public func elementEqual(to other : TableViewRow) -> Bool
-        {
-            guard let other = other as? TableView.Row<Element> else {
-                return false
+        self.element.apply(to: view, reason: reason)
+    }
+    
+    public func dequeueView(in tableView: UITableView) -> UITableViewHeaderFooterView
+    {
+        let view : Element.HeaderFooterView = {
+            if let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: self.reuseIdentifier.stringValue) {
+                return view as! Element.HeaderFooterView
+            } else {
+                return Element.createReusableHeaderFooterView(with: self.reuseIdentifier)
             }
-            
-            return self.elementEqual(to: other)
+        }()
+        
+        self.element.apply(to: view, reason: .willDisplay)
+        
+        return view
+    }
+    
+    public func updatedComparedTo(old : TableViewHeaderFooter) -> Bool
+    {
+        guard let old = old as? HeaderFooter<Element> else {
+            return true
         }
         
-        internal func elementEqual(to other : TableView.Row<Element>) -> Bool
-        {
+        return self.element.wasUpdated(comparedTo: old.element)
+    }
+    
+    public func movedComparedTo(old : TableViewHeaderFooter) -> Bool
+    {
+        guard let old = old as? HeaderFooter<Element> else {
+            return true
+        }
+        
+        return self.element.wasMoved(comparedTo: old.element)
+    }
+}
+
+public struct Row<Element:TableViewRowElement> : TableViewRow
+{
+    public var identifier : AnyIdentifier
+    
+    public var element : Element
+    
+    public var sizing : AxisSizing
+    
+    public var configuration : TableView.CellConfiguration
+    
+    public var leadingActions : SwipeActions?
+    public var trailingActions : SwipeActions?
+    
+    public typealias OnTap = (Element) -> ()
+    public var onTap : OnTap?
+    
+    public typealias OnDisplay = (Element) -> ()
+    public var onDisplay : OnDisplay?
+    
+    private let reuseIdentifier : ReuseIdentifier<Element>
+    
+    public typealias CreateBinding = (Element) -> Binding<Element>
+    internal let bind : CreateBinding?
+    
+    public init(
+        _ element : Element,
+        sizing : AxisSizing = .default,
+        configuration : TableView.CellConfiguration = .default,
+        leadingActions : SwipeActions? = nil,
+        trailingActions : SwipeActions? = nil,
+        bind : CreateBinding? = nil,
+        onDisplay : OnDisplay? = nil,
+        onTap : OnTap? = nil
+        )
+    {
+        self.element = element
+        
+        self.reuseIdentifier = ReuseIdentifier.identifier(for: self.element)
+        
+        self.identifier = AnyIdentifier(element.identifier)
+        
+        self.sizing = sizing
+        
+        self.configuration = configuration
+        
+        self.leadingActions = leadingActions
+        self.trailingActions = trailingActions
+        
+        self.bind = bind
+        
+        self.onDisplay = onDisplay
+        
+        if onTap == nil {
+            self.configuration.selectionStyle = .none
+        }
+        
+        self.onTap = onTap
+    }
+    
+    // MARK: TableViewRow
+    
+    public func elementEqual(to other : TableViewRow) -> Bool
+    {
+        guard let other = other as? Row<Element> else {
             return false
         }
         
-        // MARK: TableViewRow_Internal
-        
-        public func heightWith(width : CGFloat, default defaultHeight : CGFloat, measurementCache : ReusableViewCache) -> CGFloat
-        {
-            return self.element.measureCell(with: self.sizing, width: width, defaultHeight: defaultHeight, in: measurementCache)
-        }
-        
-        public func dequeueCell(in tableView: UITableView) -> UITableViewCell
-        {
-            let cell = self.element.cellForDisplay(in: tableView)
-            
-            self.element.apply(to: cell, reason: .willDisplay)
-            self.configuration.apply(to: cell)
-            
-            return cell
-        }
-        
-        public func performOnTap()
-        {
-            self.onTap?(self.element)
-        }
-        
-        public func updatedComparedTo(old : TableViewRow) -> Bool
-        {
-            guard let old = old as? TableView.Row<Element> else {
-                return true
-            }
-            
-            return self.element.wasUpdated(comparedTo: old.element)
-        }
-        
-        public var updateStrategy : UpdateStrategy {
-            return self.element.updateStrategy
-        }
-        
-        public func movedComparedTo(old : TableViewRow) -> Bool
-        {
-            guard let old = old as? TableView.Row<Element> else {
-                return true
-            }
-            
-            return self.element.wasMoved(comparedTo: old.element)
-        }
-        
-        @available(iOS 11.0, *)
-        public func leadingSwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
-        {
-            return self.leadingActions?.toUISwipeActionsConfiguration(onPerform: onPerform)
-        }
-        
-        @available(iOS 11.0, *)
-        public func trailingSwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
-        {
-            return self.trailingActions?.toUISwipeActionsConfiguration(onPerform: onPerform)
-        }
-        
-        public func trailingTableViewRowActions(onPerform : @escaping TableView.SwipeAction.OnPerform) -> [UITableViewRowAction]?
-        {
-            return self.trailingActions?.toUITableViewRowActions(onPerform: onPerform)
-        }
-        
-        public func newPresentationRow() -> TableViewPresentationStateRow
-        {
-            return TableView.PresentationState.Row(self)
-        }
+        return self.elementEqual(to: other)
     }
     
+    internal func elementEqual(to other : Row<Element>) -> Bool
+    {
+        return false
+    }
+    
+    // MARK: TableViewRow_Internal
+    
+    public func heightWith(width : CGFloat, default defaultHeight : CGFloat, measurementCache : ReusableViewCache) -> CGFloat
+    {
+        return self.element.measureCell(with: self.sizing, width: width, defaultHeight: defaultHeight, in: measurementCache)
+    }
+    
+    public func dequeueCell(in tableView: UITableView) -> UITableViewCell
+    {
+        let cell = self.element.cellForDisplay(in: tableView)
+        
+        self.element.apply(to: cell, reason: .willDisplay)
+        self.configuration.apply(to: cell)
+        
+        return cell
+    }
+    
+    public func performOnTap()
+    {
+        self.onTap?(self.element)
+    }
+    
+    public func updatedComparedTo(old : TableViewRow) -> Bool
+    {
+        guard let old = old as? Row<Element> else {
+            return true
+        }
+        
+        return self.element.wasUpdated(comparedTo: old.element)
+    }
+    
+    public var updateStrategy : UpdateStrategy {
+        return self.element.updateStrategy
+    }
+    
+    public func movedComparedTo(old : TableViewRow) -> Bool
+    {
+        guard let old = old as? Row<Element> else {
+            return true
+        }
+        
+        return self.element.wasMoved(comparedTo: old.element)
+    }
+    
+    @available(iOS 11.0, *)
+    public func leadingSwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
+    {
+        return self.leadingActions?.toUISwipeActionsConfiguration(onPerform: onPerform)
+    }
+    
+    @available(iOS 11.0, *)
+    public func trailingSwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration?
+    {
+        return self.trailingActions?.toUISwipeActionsConfiguration(onPerform: onPerform)
+    }
+    
+    public func trailingTableViewRowActions(onPerform : @escaping SwipeAction.OnPerform) -> [UITableViewRowAction]?
+    {
+        return self.trailingActions?.toUITableViewRowActions(onPerform: onPerform)
+    }
+    
+    public func newPresentationContainer() -> PresentationStateRowState
+    {
+        return PresentationState.RowState(self)
+    }
+}
+
+public extension TableView
+{
     fileprivate static func headerFooterChanged(
         _ lhs : TableViewHeaderFooter?,
         _ rhs : TableViewHeaderFooter?,
@@ -405,301 +405,296 @@ public extension TableView
     }
 }
 
-fileprivate extension TableView.Row where Element:Equatable
+fileprivate extension Row where Element:Equatable
 {
-    func elementEqual(to other : TableView.Row<Element>) -> Bool
+    func elementEqual(to other : Row<Element>) -> Bool
     {
         return self.element == other.element
     }
 }
 
-public extension TableView
+
+public struct SwipeActions
 {
-    struct SwipeActions
+    public var actions : [SwipeAction]
+    
+    public var performsFirstOnFullSwipe : Bool
+    
+    public var firstDestructiveAction : SwipeAction? {
+        return self.actions.first {
+            $0.style == .destructive
+        }
+    }
+    
+    public init(_ action : SwipeAction, performsFirstOnFullSwipe : Bool = false)
     {
-        public var actions : [SwipeAction]
+        self.init([action], performsFirstOnFullSwipe: performsFirstOnFullSwipe)
+    }
+    
+    public init(_ actions : [SwipeAction], performsFirstOnFullSwipe : Bool = false)
+    {
+        self.actions = actions
         
-        public var performsFirstOnFullSwipe : Bool
+        self.performsFirstOnFullSwipe = performsFirstOnFullSwipe
+    }
+    
+    @available(iOS 11.0, *)
+    internal func toUISwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration
+    {
+        let config = UISwipeActionsConfiguration(actions: self.actions.map {
+            $0.toUIContextualAction(onPerform: onPerform)
+        })
         
-        public var firstDestructiveAction : SwipeAction? {
-            return self.actions.first {
-                $0.style == .destructive
+        config.performsFirstActionWithFullSwipe = self.performsFirstOnFullSwipe
+        
+        return config
+    }
+    
+    internal func toUITableViewRowActions(onPerform : @escaping SwipeAction.OnPerform) -> [UITableViewRowAction]?
+    {
+        return self.actions.map {
+            $0.toUITableViewRowAction(onPerform: onPerform)
+        }
+    }
+}
+
+public struct SwipeAction
+{
+    public typealias OnPerform = (Style) -> ()
+    
+    public var title: String?
+    
+    public var style: Style = .normal
+    
+    public var backgroundColor: UIColor?
+    public var image: UIImage?
+    
+    public typealias OnTap = (SwipeAction) -> Bool
+    public var onTap : OnTap
+    
+    public init(title: String?, style: Style = .normal, backgroundColor: UIColor? = nil, image: UIImage? = nil, onTap : @escaping OnTap)
+    {
+        self.title = title
+        self.style = style
+        self.backgroundColor = backgroundColor
+        self.image = image
+        self.onTap = onTap
+    }
+    
+    @available(iOS 11.0, *)
+    internal func toUIContextualAction(onPerform : @escaping OnPerform) -> UIContextualAction
+    {
+        return UIContextualAction(
+            style: self.style.toUIContextualActionStyle(),
+            title: self.title,
+            handler: { action, view, didComplete in
+                let completed = self.onTap(self)
+                
+                if completed {
+                    onPerform(self.style)
+                }
+                
+                didComplete(completed)
+        })
+    }
+    
+    internal func toUITableViewRowAction(onPerform : @escaping OnPerform) -> UITableViewRowAction
+    {
+        return UITableViewRowAction(
+            style: self.style.toUITableViewRowActionStyle(),
+            title: self.title,
+            handler: { _, _ in
+                let completed = self.onTap(self)
+                
+                if completed {
+                    onPerform(self.style)
+                }
+        })
+    }
+    
+    public enum Style
+    {
+        case normal
+        case destructive
+        
+        public var deletesRow : Bool {
+            switch self {
+            case .normal: return false
+            case .destructive: return true
             }
         }
         
-        public init(_ action : SwipeAction, performsFirstOnFullSwipe : Bool = false)
-        {
-            self.init([action], performsFirstOnFullSwipe: performsFirstOnFullSwipe)
-        }
-        
-        public init(_ actions : [SwipeAction], performsFirstOnFullSwipe : Bool = false)
-        {
-            self.actions = actions
-            
-            self.performsFirstOnFullSwipe = performsFirstOnFullSwipe
-        }
-        
         @available(iOS 11.0, *)
-        internal func toUISwipeActionsConfiguration(onPerform : @escaping SwipeAction.OnPerform) -> UISwipeActionsConfiguration
+        func toUIContextualActionStyle() -> UIContextualAction.Style
         {
-            let config = UISwipeActionsConfiguration(actions: self.actions.map {
-                $0.toUIContextualAction(onPerform: onPerform)
-            })
-            
-            config.performsFirstActionWithFullSwipe = self.performsFirstOnFullSwipe
-            
-            return config
+            switch self {
+            case .normal: return .normal
+            case .destructive: return .destructive
+            }
         }
         
-        internal func toUITableViewRowActions(onPerform : @escaping SwipeAction.OnPerform) -> [UITableViewRowAction]?
+        func toUITableViewRowActionStyle() -> UITableViewRowAction.Style
         {
-            return self.actions.map {
-                $0.toUITableViewRowAction(onPerform: onPerform)
+            switch self {
+            case .normal: return .normal
+            case .destructive: return .destructive
+            }
+        }
+    }
+}
+
+
+public struct Content
+{
+    public let refreshControl : RefreshControl?
+    
+    public let header : TableViewHeaderFooter?
+    public let footer : TableViewHeaderFooter?
+    
+    public var sections : [Section]
+    
+    public var rowCount : Int {
+        return self.sections.reduce(0, { $0 + $1.rows.count })
+    }
+    
+    public init(
+        refreshControl : RefreshControl? = nil,
+        header : TableViewHeaderFooter? = nil,
+        footer : TableViewHeaderFooter? = nil,
+        sections : [Section] = []
+        )
+    {
+        self.refreshControl = refreshControl
+        
+        self.header = header
+        self.footer = footer
+        
+        self.sections = sections
+    }
+    
+    public func row(at indexPath : IndexPath) -> TableViewRow
+    {
+        let section = self.sections[indexPath.section]
+        let row = section.rows[indexPath.row]
+        
+        return row
+    }
+    
+    public func indexPath(for identifier : AnyIdentifier) -> IndexPath?
+    {
+        return self.row(for: identifier)?.indexPath
+    }
+    
+    func row(for identifier : AnyIdentifier) -> (indexPath:IndexPath, row:TableViewRow)?
+    {
+        for (sectionIndex, section) in self.sections.enumerated() {
+            for (rowIndex, row) in section.rows.enumerated() {
+                if row.identifier == identifier {
+                    return (IndexPath(row: rowIndex, section: sectionIndex), row)
+                }
+            }
+        }
+        
+        return nil
+    }
+    
+    mutating func remove(at indexPath : IndexPath)
+    {
+        self.sections[indexPath.section].rows.remove(at: indexPath.row)
+    }
+    
+    //
+    // MARK: Slicing
+    //
+    
+    struct Slice
+    {
+        static let defaultSize : Int = 250
+        
+        let containsAllRows : Bool
+        var content : Content
+        
+        init(containsAllRows : Bool, content : Content)
+        {
+            self.containsAllRows = containsAllRows
+            self.content = content
+        }
+        
+        init()
+        {
+            self.containsAllRows = true
+            self.content = Content(sections: [])
+        }
+        
+        enum UpdateReason : Equatable
+        {
+            case scrolledDown
+            case didEndDecelerating
+            
+            case scrolledToTop
+            
+            case contentChanged(animated : Bool)
+            
+            var diffsChanges : Bool {
+                /*
+                 We only diff in the case of content change to avoid visual artifacts in the table view;
+                 even with no animation type provided to batch update methods, the table view still moves
+                 rows around in an animated manner.
+                 */
+                switch self {
+                case .scrolledDown: return false
+                case .didEndDecelerating: return false
+                case .scrolledToTop: return false
+                    
+                case .contentChanged(_): return true
+                }
+            }
+            
+            var animated : Bool {
+                switch self {
+                case .scrolledDown: return false
+                case .didEndDecelerating: return false
+                case .scrolledToTop: return false
+                    
+                case .contentChanged(let animated): return animated
+                }
             }
         }
     }
     
-    struct SwipeAction
+    internal func sliceTo(indexPath : IndexPath, plus additionalRows : Int) -> Slice
     {
-        public typealias OnPerform = (Style) -> ()
+        var sliced = self
         
-        public var title: String?
+        var remaining : Int = indexPath.row + additionalRows
         
-        public var style: Style = .normal
-        
-        public var backgroundColor: UIColor?
-        public var image: UIImage?
-        
-        public typealias OnTap = (SwipeAction) -> Bool
-        public var onTap : OnTap
-        
-        public init(title: String?, style: Style = .normal, backgroundColor: UIColor? = nil, image: UIImage? = nil, onTap : @escaping OnTap)
-        {
-            self.title = title
-            self.style = style
-            self.backgroundColor = backgroundColor
-            self.image = image
-            self.onTap = onTap
-        }
-        
-        @available(iOS 11.0, *)
-        internal func toUIContextualAction(onPerform : @escaping OnPerform) -> UIContextualAction
-        {
-            return UIContextualAction(
-                style: self.style.toUIContextualActionStyle(),
-                title: self.title,
-                handler: { action, view, didComplete in
-                    let completed = self.onTap(self)
-                    
-                    if completed {
-                        onPerform(self.style)
-                    }
-                    
-                    didComplete(completed)
-            })
-        }
-        
-        internal func toUITableViewRowAction(onPerform : @escaping OnPerform) -> UITableViewRowAction
-        {
-            return UITableViewRowAction(
-                style: self.style.toUITableViewRowActionStyle(),
-                title: self.title,
-                handler: { _, _ in
-                    let completed = self.onTap(self)
-                    
-                    if completed {
-                        onPerform(self.style)
-                    }
-            })
-        }
-        
-        public enum Style
-        {
-            case normal
-            case destructive
-            
-            public var deletesRow : Bool {
-                switch self {
-                case .normal: return false
-                case .destructive: return true
+        sliced.sections = self.sections.compactMapWithIndex { sectionIndex, section in
+            if sectionIndex < indexPath.section {
+                return section
+            } else {
+                guard remaining > 0 else {
+                    return nil
                 }
-            }
-            
-            @available(iOS 11.0, *)
-            func toUIContextualActionStyle() -> UIContextualAction.Style
-            {
-                switch self {
-                case .normal: return .normal
-                case .destructive: return .destructive
-                }
-            }
-            
-            func toUITableViewRowActionStyle() -> UITableViewRowAction.Style
-            {
-                switch self {
-                case .normal: return .normal
-                case .destructive: return .destructive
-                }
+                
+                var section = section
+                section.rows = section.rowsUpTo(limit: remaining)
+                remaining -= section.rows.count
+                
+                return section
             }
         }
+        
+        return Slice(
+            containsAllRows: self.rowCount == sliced.rowCount,
+            content: sliced
+        )
     }
 }
 
 
-public extension TableView
+public extension Content
 {
-    struct Content
-    {
-        public let refreshControl : RefreshControl?
-        
-        public let header : TableViewHeaderFooter?
-        public let footer : TableViewHeaderFooter?
-        
-        public var sections : [TableView.Section]
-        
-        public var rowCount : Int {
-            return self.sections.reduce(0, { $0 + $1.rows.count })
-        }
-        
-        public init(
-            refreshControl : RefreshControl? = nil,
-            header : TableViewHeaderFooter? = nil,
-            footer : TableViewHeaderFooter? = nil,
-            sections : [TableView.Section] = []
-            )
-        {
-            self.refreshControl = refreshControl
-            
-            self.header = header
-            self.footer = footer
-            
-            self.sections = sections
-        }
-        
-        public func row(at indexPath : IndexPath) -> TableViewRow
-        {
-            let section = self.sections[indexPath.section]
-            let row = section.rows[indexPath.row]
-            
-            return row
-        }
-        
-        public func indexPath(for identifier : AnyIdentifier) -> IndexPath?
-        {
-            return self.row(for: identifier)?.indexPath
-        }
-        
-        func row(for identifier : AnyIdentifier) -> (indexPath:IndexPath, row:TableViewRow)?
-        {
-            for (sectionIndex, section) in self.sections.enumerated() {
-                for (rowIndex, row) in section.rows.enumerated() {
-                    if row.identifier == identifier {
-                        return (IndexPath(row: rowIndex, section: sectionIndex), row)
-                    }
-                }
-            }
-            
-            return nil
-        }
-        
-        mutating func remove(at indexPath : IndexPath)
-        {
-            self.sections[indexPath.section].rows.remove(at: indexPath.row)
-        }
-        
-        //
-        // MARK: Slicing
-        //
-        
-        struct Slice
-        {
-            static let defaultSize : Int = 250
-            
-            let containsAllRows : Bool
-            var content : Content
-            
-            init(containsAllRows : Bool, content : Content)
-            {
-                self.containsAllRows = containsAllRows
-                self.content = content
-            }
-            
-            init()
-            {
-                self.containsAllRows = true
-                self.content = Content(sections: [])
-            }
-            
-            enum UpdateReason : Equatable
-            {
-                case scrolledDown
-                case didEndDecelerating
-                
-                case scrolledToTop
-                
-                case contentChanged(animated : Bool)
-                
-                var diffsChanges : Bool {
-                    /*
-                     We only diff in the case of content change to avoid visual artifacts in the table view;
-                     even with no animation type provided to batch update methods, the table view still moves
-                     rows around in an animated manner.
-                     */
-                    switch self {
-                    case .scrolledDown: return false
-                    case .didEndDecelerating: return false
-                    case .scrolledToTop: return false
-                        
-                    case .contentChanged(_): return true
-                    }
-                }
-                
-                var animated : Bool {
-                    switch self {
-                    case .scrolledDown: return false
-                    case .didEndDecelerating: return false
-                    case .scrolledToTop: return false
-                        
-                    case .contentChanged(let animated): return animated
-                    }
-                }
-            }
-        }
-        
-        internal func sliceTo(indexPath : IndexPath, plus additionalRows : Int) -> Slice
-        {
-            var sliced = self
-            
-            var remaining : Int = indexPath.row + additionalRows
-            
-            sliced.sections = self.sections.compactMapWithIndex { sectionIndex, section in
-                if sectionIndex < indexPath.section {
-                    return section
-                } else {
-                    guard remaining > 0 else {
-                        return nil
-                    }
-                    
-                    var section = section
-                    section.rows = section.rowsUpTo(limit: remaining)
-                    remaining -= section.rows.count
-                    
-                    return section
-                }
-            }
-            
-            return Slice(
-                containsAllRows: self.rowCount == sliced.rowCount,
-                content: sliced
-            )
-        }
-    }
-}
-
-
-public extension TableView.Content
-{
-    func elementsEqual(to other : TableView.Content) -> Bool
+    func elementsEqual(to other : Content) -> Bool
     {
         if self.sections.count != other.sections.count {
             return false
@@ -713,9 +708,10 @@ public extension TableView.Content
     }
 }
 
-public extension TableView.Section
+
+public extension Section
 {
-    func elementsEqual(to other : TableView.Section) -> Bool
+    func elementsEqual(to other : Section) -> Bool
     {
         if self.rows.count != other.rows.count {
             return false

--- a/ListableTableView/Sources/TableView.swift
+++ b/ListableTableView/Sources/TableView.swift
@@ -54,7 +54,7 @@ public final class TableView : UIView
     {
         self.sourcePresenter.discard()
         
-        let sourcePresenter = TableView.SourcePresenter(initial: initial, source: source) { [weak self] in
+        let sourcePresenter = SourcePresenter(initial: initial, source: source) { [weak self] in
             self?.reloadContent(animated: animated)
         }
         
@@ -115,23 +115,23 @@ public final class TableView : UIView
         frame: CGRect = .zero,
         style : UITableView.Style = .plain,
         state : State,
-        _ builder : @escaping (SourceState<State>, inout TableView.ContentBuilder) -> ()
+        _ builder : @escaping (SourceState<State>, inout ContentBuilder) -> ()
         )
     {
         self.init(frame: frame, style: style)
         
-        self.setSource(initial: state, source: TableView.DynamicSource(with: builder))
+        self.setSource(initial: state, source: DynamicSource(with: builder))
     }
     
     public convenience init(
         frame: CGRect = .zero,
         style : UITableView.Style = .plain,
-        _ builder : @escaping (inout TableView.ContentBuilder) -> ()
+        _ builder : @escaping (inout ContentBuilder) -> ()
         )
     {
         self.init(frame: frame, style: style)
         
-        self.setSource(initial: TableView.StaticSource.State(), source: TableView.StaticSource(with: builder))
+        self.setSource(initial: StaticSource.State(), source: StaticSource(with: builder))
     }
     
     public init(frame: CGRect = .zero, style : UITableView.Style = .plain)
@@ -188,7 +188,7 @@ public final class TableView : UIView
     public struct VisibleSection
     {
         public let index : Int
-        public let section : TableView.Section
+        public let section : Section
     }
     
     public var visibleSections : [VisibleSection] {
@@ -288,21 +288,6 @@ public final class TableView : UIView
     }
 }
 
-public protocol TableViewPresentationStateRow : TableViewPresentationStateRow_Internal
-{
-}
-
-public protocol TableViewPresentationStateRow_Internal : AnyObject
-{
-    var anyIdentifier : AnyIdentifier { get }
-    var anyModel : TableViewRow { get }
-    
-    func update(with old : TableViewRow, new : TableViewRow)
-    
-    func willDisplay(with cell : UITableViewCell)
-    func didEndDisplay()
-}
-
 
 fileprivate extension TableView
 {
@@ -311,7 +296,7 @@ fileprivate extension TableView
         
         var content : Content = Content()
         
-        func remove(row rowToRemove : TableViewPresentationStateRow) -> IndexPath?
+        func remove(row rowToRemove : PresentationStateRowState) -> IndexPath?
         {
             if let indexPath = self.presentationState.remove(row: rowToRemove) {
                 self.content.remove(at: indexPath)
@@ -326,7 +311,7 @@ fileprivate extension TableView
     {
         unowned var tableView : TableView!
         
-        var presentationState : TableView.PresentationState {
+        var presentationState : PresentationState {
             return self.tableView.storage.presentationState
         }
         
@@ -370,7 +355,7 @@ fileprivate extension TableView
     {
         unowned var tableView : TableView!
         
-        var presentationState : TableView.PresentationState {
+        var presentationState : PresentationState {
             return self.tableView.storage.presentationState
         }
         
@@ -452,7 +437,7 @@ fileprivate extension TableView
         
         // MARK: Display
         
-        var displayedRows : [ObjectIdentifier:TableViewPresentationStateRow] = [:]
+        var displayedRows : [ObjectIdentifier:PresentationStateRowState] = [:]
         
         func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath)
         {
@@ -492,7 +477,7 @@ fileprivate extension TableView
         
         // MARK: Row Actions
         
-        func performedActionFor(row : TableViewPresentationStateRow, style : TableView.SwipeAction.Style)
+        func performedActionFor(row : PresentationStateRowState, style : SwipeAction.Style)
         {
             if style.deletesRow {
                 if let indexPath = self.tableView.storage.remove(row: row) {
@@ -583,7 +568,7 @@ fileprivate extension UITableView
         return self.contentOffset.y + (viewHeight * 1.5) > self.contentSize.height
     }
     
-    func update(with diff : SectionedDiff<TableView.Section,TableViewRow>, animated: Bool, onBeginUpdates : () -> ())
+    func update(with diff : SectionedDiff<Section,TableViewRow>, animated: Bool, onBeginUpdates : () -> ())
     {
         self.beginUpdates()
         onBeginUpdates()


### PR DESCRIPTION
This cleans up the usage of the API significantly, so you no longer need to do `TableView.Row`, `TableView.Section`, etc.