### PR TITLE
Fix measurement rounding

### DIFF
--- a/Listable/Sources/Sizing.swift
+++ b/Listable/Sources/Sizing.swift
@@ -58,7 +58,7 @@ public enum Sizing : Equatable
             }
         }()
         
-        return value.rounded()
+        return ceil(value)
     }
     
     public enum ConstraintValue : Equatable


### PR DESCRIPTION
- Ceil measured values, so they are not rounded down, which may cause text to not fit.