### PR TITLE
Support overscroll footers

### DIFF
--- a/Demo/Sources/CollectionView/CollectionViewBasicDemoViewController.swift
+++ b/Demo/Sources/CollectionView/CollectionViewBasicDemoViewController.swift
@@ -44,6 +44,10 @@ final class CollectionViewBasicDemoViewController : UIViewController
     {
         listView.setContent { list in
             
+            list.content.overscrollFooter = HeaderFooter(
+                with: DemoHeader(title: "Thanks for using Listable!!")
+            )
+            
             list.animatesChanges = animated
             
             list += self.rows.map { sectionRows in

--- a/Demo/Sources/CollectionView/KeyboardTestingViewController.swift
+++ b/Demo/Sources/CollectionView/KeyboardTestingViewController.swift
@@ -24,6 +24,10 @@ final class KeyboardTestingViewController : UIViewController
         self.listView.appearance.layout.itemSpacing = 10.0
         
         self.listView.setContent { list in
+            list.content.overscrollFooter = HeaderFooter(
+                with: DemoHeader(title: "Thanks for using Listable!!")
+            )
+            
             list += Section(identifier: "section") { section in
                 section += Item(with: TextFieldElement(content: "Item 1"), sizing: .fixed(100.0))
                 section += Item(with: TextFieldElement(content: "Item 2"), sizing: .fixed(100.0))

--- a/Demo/Sources/DemosRootViewController.swift
+++ b/Demo/Sources/DemosRootViewController.swift
@@ -30,6 +30,11 @@ public final class DemosRootViewController : UIViewController
         self.listView.appearance = demoAppearance
         
         self.listView.setContent { list in
+            
+            list.content.overscrollFooter = HeaderFooter(
+                with: DemoHeader(title: "Thanks for using Listable!!")
+            )
+            
             list += Section(identifier: "collection-view") { section in
                 
                 section.header = HeaderFooter(

--- a/Listable/Sources/Appearance.swift
+++ b/Listable/Sources/Appearance.swift
@@ -58,6 +58,7 @@ public struct ListSizing : Equatable
     
     public var listHeaderHeight : CGFloat
     public var listFooterHeight : CGFloat
+    public var overscrollFooterHeight : CGFloat
     
     public var itemPositionGroupingHeight : CGFloat
         
@@ -67,6 +68,7 @@ public struct ListSizing : Equatable
         sectionFooterHeight : CGFloat = 40.0,
         listHeaderHeight : CGFloat = 60.0,
         listFooterHeight : CGFloat = 60.0,
+        overscrollFooterHeight : CGFloat = 60.0,
         itemPositionGroupingHeight : CGFloat = 0.0
     )
     {
@@ -75,6 +77,7 @@ public struct ListSizing : Equatable
         self.sectionFooterHeight = sectionFooterHeight
         self.listHeaderHeight = listHeaderHeight
         self.listFooterHeight = listFooterHeight
+        self.overscrollFooterHeight = overscrollFooterHeight
         self.itemPositionGroupingHeight = itemPositionGroupingHeight
     }
     

--- a/Listable/Sources/Content.swift
+++ b/Listable/Sources/Content.swift
@@ -27,6 +27,8 @@ public struct Content
     public var header : AnyHeaderFooter?
     public var footer : AnyHeaderFooter?
     
+    public var overscrollFooter : AnyHeaderFooter?
+    
     public var sections : [Section]
     
     public var itemCount : Int {
@@ -56,6 +58,7 @@ public struct Content
         refreshControl : RefreshControl? = nil,
         header : AnyHeaderFooter? = nil,
         footer : AnyHeaderFooter? = nil,
+        overscrollFooter : AnyHeaderFooter? = nil,
         sections : [Section] = []
         )
     {
@@ -67,6 +70,8 @@ public struct Content
         
         self.header = header
         self.footer = footer
+        
+        self.overscrollFooter = overscrollFooter
         
         self.sections = sections
     }

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -86,6 +86,7 @@ final class PresentationState
     
     var header : AnyPresentationHeaderFooterState?
     var footer : AnyPresentationHeaderFooterState?
+    var overscrollFooter : AnyPresentationHeaderFooterState?
     
     var sections : [PresentationState.SectionState]
         
@@ -254,7 +255,9 @@ final class PresentationState
         
         self.header = SectionState.headerFooterState(with: self.header, new: slice.content.header)
         self.footer = SectionState.headerFooterState(with: self.footer, new: slice.content.footer)
-                
+        
+        self.overscrollFooter = SectionState.headerFooterState(with: self.overscrollFooter, new: slice.content.overscrollFooter)
+                        
         self.sections = diff.changes.transform(
             old: self.sections,
             removed: { _, _ in },

--- a/Listable/Sources/LayoutDirection.swift
+++ b/Listable/Sources/LayoutDirection.swift
@@ -94,4 +94,20 @@ public enum LayoutDirection : Hashable
         case .horizontal: return HorizontalPadding(left: insets.bottom, right: insets.top)
         }
     }
+    
+    public func top(with insets : UIEdgeInsets) -> CGFloat
+    {
+        switch self {
+        case .vertical: return insets.top
+        case .horizontal: return insets.left
+        }
+    }
+    
+    public func bottom(with insets : UIEdgeInsets) -> CGFloat
+    {
+        switch self {
+        case .vertical: return insets.bottom
+        case .horizontal: return insets.right
+        }
+    }
 }

--- a/Listable/Sources/ListView/ListView.DataSource.swift
+++ b/Listable/Sources/ListView/ListView.DataSource.swift
@@ -33,7 +33,11 @@ internal extension ListView
             return item.dequeueAndPrepareCollectionViewCell(in: collectionView, for: indexPath)
         }
         
-        func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView
+        func collectionView(
+            _ collectionView: UICollectionView,
+            viewForSupplementaryElementOfKind kind: String,
+            at indexPath: IndexPath
+            ) -> UICollectionReusableView
         {
             switch ListViewLayout.SupplementaryKind(rawValue: kind)! {
             case .listHeader:
@@ -63,6 +67,12 @@ internal extension ListView
                     self.presentationState.registerSupplementaryView(of: kind, for: footer)
                     return footer.dequeueAndPrepareCollectionReusableView(in: collectionView, of: kind, for: indexPath)
                 }
+                
+            case .overscrollFooter:
+                if let footer = self.presentationState.overscrollFooter {
+                    self.presentationState.registerSupplementaryView(of: kind, for: footer)
+                    return footer.dequeueAndPrepareCollectionReusableView(in: collectionView, of: kind, for: indexPath)
+                }
             }
             
             fatalError()
@@ -75,7 +85,11 @@ internal extension ListView
             return item.anyModel.reordering != nil
         }
         
-        func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath)
+        func collectionView(
+            _ collectionView: UICollectionView,
+            moveItemAt sourceIndexPath: IndexPath,
+            to destinationIndexPath: IndexPath
+            )
         {
             let item = self.presentationState.item(at: destinationIndexPath)
             

--- a/Listable/Tests/AppearanceTests.swift
+++ b/Listable/Tests/AppearanceTests.swift
@@ -38,6 +38,7 @@ class ListSizingTests : XCTestCase
         XCTAssertEqual(sizing.sectionFooterHeight, 40.0)
         XCTAssertEqual(sizing.listHeaderHeight, 60.0)
         XCTAssertEqual(sizing.listFooterHeight, 60.0)
+        XCTAssertEqual(sizing.overscrollFooterHeight, 60.0)
         XCTAssertEqual(sizing.itemPositionGroupingHeight, 0.0)
     }
 }


### PR DESCRIPTION
This PR adds support for "overscroll" footers, aka what is showed when a user drags up so that content below the end of the table is visible.

It also cleans up the layout code for stickyheaders to be similar to the code for overscroll – it's easier to do this on each layout prepare() call (and usually needed), so avoid lumping this into the NeededLayoutType enum.

No scroll:

<img width="300" alt="Screen Shot 2019-12-11 at 9 14 10 PM" src="https://user-images.githubusercontent.com/327847/70684512-4006a380-1c5b-11ea-99dc-9c5d41f2df11.png">

Scrolled:

<img width="300" alt="Screen Shot 2019-12-11 at 9 14 25 PM" src="https://user-images.githubusercontent.com/327847/70684516-44cb5780-1c5b-11ea-822a-ef73ed7ac109.png">
