### PR TITLE
Fix content inset issues with scroll indicators and keyboard insets

### DIFF
--- a/Listable/Sources/ListView/ListView.swift
+++ b/Listable/Sources/ListView/ListView.swift
@@ -719,11 +719,17 @@ extension ListView : KeyboardObserverDelegate
             return
         }
         
-        var inset : CGFloat
+        let inset : CGFloat
         
         switch frame {
-        case .notVisible: inset = 0.0
-        case .visible(let frame): inset = (self.bounds.size.height - frame.origin.y)
+        case .notVisible:
+            inset = 0.0
+        case .visible(let frame):
+            if #available(iOS 11, *) {
+                inset = (self.bounds.size.height - frame.origin.y) - self.safeAreaInsets.bottom
+            } else {
+                inset = (self.bounds.size.height - frame.origin.y)
+            }
         }
         
         self.collectionView.contentInset.bottom = inset

--- a/Listable/Sources/ListView/ListView.swift
+++ b/Listable/Sources/ListView/ListView.swift
@@ -169,10 +169,13 @@ public final class ListView : UIView
     
     func applyScrollInsets()
     {
-        self.collectionView.contentInset = self.scrollInsets.insets(
+        let insets = self.scrollInsets.insets(
             with: self.collectionView.contentInset,
             layoutDirection: self.appearance.direction
         )
+
+        self.collectionView.contentInset = insets
+        self.collectionView.scrollIndicatorInsets = insets
     }
     
     //
@@ -724,6 +727,7 @@ extension ListView : KeyboardObserverDelegate
         }
         
         self.collectionView.contentInset.bottom = inset
+        self.collectionView.scrollIndicatorInsets.bottom = inset
     }
     
     //


### PR DESCRIPTION
- Fixes https://github.com/kyleve/Listable/issues/100
- Fixes https://github.com/kyleve/Listable/issues/99

This PR fixes an issue with the scroll indicator insets not being set to match the content insets, which is almost always the correct behavior. In the first GIF you can see the scroll indicator disappears behind the keyboard, while the in the second gif it matches the content size. 

This PR also fixes an issue when calculating the inset to add to adjust for a visible keyboard. I chose to subtract the bottom content inset from the calculation, as the collection view keeps the safe area inset in addition to insets you set. Another option might be to disable safe area inset adjustments entirely, but then we would lose the automatic adjustment when in most cases we want it. In the first GIF you can see the gap between the collection view content and the keyboard. In the second, there's no gap. Both have the correct safe area when the keyboard is not visible.

| Before | After |
|-|-|
| ![Kapture 2020-03-06 at 10 07 32](https://user-images.githubusercontent.com/3526783/76110237-0364f280-5f93-11ea-8b44-410b6839cc5e.gif) | ![Kapture 2020-03-06 at 10 05 11](https://user-images.githubusercontent.com/3526783/76110247-0829a680-5f93-11ea-8651-e91b7d3ca5e3.gif) |
