### PR TITLE
[WIP] Swipe to action v1

### DIFF
--- a/BlueprintLists/Sources/Item.swift
+++ b/BlueprintLists/Sources/Item.swift
@@ -47,6 +47,7 @@ public extension Listable.Item where Element : BlueprintItemElement
         layout : ItemLayout = ItemLayout(),
         selection : ItemSelection = .notSelectable,
         swipeActions : SwipeActions? = nil,
+        swipeActionsAppearance : Element.SwipeActionsAppearance? = nil,
         reordering : Reordering? = nil,
         bind : CreateBinding? = nil,
         onDisplay : OnDisplay? = nil,
@@ -61,6 +62,7 @@ public extension Listable.Item where Element : BlueprintItemElement
             layout: layout,
             selection: selection,
             swipeActions: swipeActions,
+            swipeActionsAppearance: swipeActionsAppearance,
             reordering: reordering,
             bind: bind,
             onDisplay: onDisplay,
@@ -84,6 +86,7 @@ public extension BlueprintItemElement
     {
         view.element = self.element(with: info)
     }
+    
 }
 
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0AAA0EB1236367D000B32F63 /* ItemizationEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA0EB0236367D000B32F63 /* ItemizationEditorViewController.swift */; };
 		0AB8B0D2237CD47A00CBC434 /* ReorderingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB8B0D1237CD47A00CBC434 /* ReorderingViewController.swift */; };
 		0AE855512390933100F2E245 /* Test_Targets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE855502390933100F2E245 /* Test_Targets.swift */; };
+		0AEA09BD242A941700F9ED0C /* DemoTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEA09BC242A941700F9ED0C /* DemoTableViewController.swift */; };
 		0AEB96B922FBCBA600341DFF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AEB96B822FBCBA600341DFF /* Assets.xcassets */; };
 		0AEB96BC22FBCBA600341DFF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AEB96BA22FBCBA600341DFF /* LaunchScreen.storyboard */; };
 		0AEB96DE22FBCC1D00341DFF /* CollectionViewBasicDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEB96CE22FBCC1D00341DFF /* CollectionViewBasicDemoViewController.swift */; };
@@ -60,6 +61,7 @@
 		0AE8554E2390933100F2E245 /* Test Targets.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Test Targets.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AE855502390933100F2E245 /* Test_Targets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Targets.swift; sourceTree = "<group>"; };
 		0AE855522390933100F2E245 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0AEA09BC242A941700F9ED0C /* DemoTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTableViewController.swift; sourceTree = "<group>"; };
 		0AEB96AE22FBCBA500341DFF /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AEB96B822FBCBA600341DFF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0AEB96BB22FBCBA600341DFF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				0AB8B0D1237CD47A00CBC434 /* ReorderingViewController.swift */,
 				0A3FFA6C238336870080E0D9 /* InvoicesPaymentScheduleDemoViewController.swift */,
 				0A58D85023CD3FCF00583C25 /* FlowLayoutViewController.swift */,
+				0AEA09BC242A941700F9ED0C /* DemoTableViewController.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -396,6 +399,7 @@
 				0A590004236A371600F463DA /* CollectionViewDictionaryDemoViewController.swift in Sources */,
 				0A46A00B23793C0200B35811 /* WidthCustomizationViewController.swift in Sources */,
 				0A46A005237892C100B35811 /* HorizontalLayoutViewController.swift in Sources */,
+				0AEA09BD242A941700F9ED0C /* DemoTableViewController.swift in Sources */,
 				0A2378402373B0010048092A /* KeyboardTestingViewController.swift in Sources */,
 				0A3FFA6D238336870080E0D9 /* InvoicesPaymentScheduleDemoViewController.swift in Sources */,
 				0AB8B0D2237CD47A00CBC434 /* ReorderingViewController.swift in Sources */,

--- a/Demo/Sources/CollectionView/DemoTableViewController.swift
+++ b/Demo/Sources/CollectionView/DemoTableViewController.swift
@@ -1,0 +1,48 @@
+//
+//  DemoTableViewController.swift
+//  Demo
+//
+//  Created by Kyle Van Essen on 3/24/20.
+//  Copyright © 2020 Kyle Van Essen. All rights reserved.
+//
+
+import UIKit
+
+
+final class DemoTableViewController : UITableViewController
+{
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int
+    {
+        return 10
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell
+    {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell")!
+        
+        cell.textLabel?.text = "Hello, World!"
+        
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat
+    {
+        return 80.0
+    }
+    
+    @available(iOS 11.0, *)
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration?
+    {
+        return UISwipeActionsConfiguration(
+            actions: [
+                UIContextualAction(style: .destructive, title: "Delete", handler: { _, _, _ in }),
+                UIContextualAction(style: .destructive, title: "Delete", handler: { _, _, _ in })
+        ])
+    }
+}

--- a/Demo/Sources/CollectionViewAppearance.swift
+++ b/Demo/Sources/CollectionViewAppearance.swift
@@ -88,6 +88,8 @@ struct DemoItem : BlueprintItemElement, Equatable
     var identifier: Identifier<DemoItem> {
         return .init(self.text)
     }
+
+    typealias SwipeActionsAppearance = DefaultItemElementSwipeActionsAppearance
     
     func element(with info : ApplyItemElementInfo) -> Element
     {

--- a/Demo/Sources/DemosRootViewController.swift
+++ b/Demo/Sources/DemosRootViewController.swift
@@ -129,12 +129,15 @@ public final class DemosRootViewController : UIViewController
                     with: DemoItem(text: "Swipe To Action"),
                     selection: .isSelectable(isSelected: false),
                     swipeActions: SwipeActions(SwipeAction(
-                    title: "Delete",
-                    backgroundColor: .purple,
-                    image: nil, onTap: { _ in
-                        print("Delete")
-                        return true
-                    }), performsFirstOnFullSwipe: false),
+                        title: "Delete",
+                        backgroundColor: .purple,
+                        image: nil,
+                        onTap: { _ in
+                            print("Deleted")
+                            return true
+                        }
+                    ),performsFirstOnFullSwipe: true),
+                    swipeActionsAppearance: DefaultItemElementSwipeActionsAppearance(),
                     onSelect : { _ in
                         self.push(DemoTableViewController())
                 })

--- a/Demo/Sources/DemosRootViewController.swift
+++ b/Demo/Sources/DemosRootViewController.swift
@@ -134,7 +134,7 @@ public final class DemosRootViewController : UIViewController
                     image: nil, onTap: { _ in
                         print("Delete")
                         return true
-                    }), performsFirstOnFullSwipe: true),
+                    }), performsFirstOnFullSwipe: false),
                     onSelect : { _ in
                         self.push(DemoTableViewController())
                 })

--- a/Demo/Sources/DemosRootViewController.swift
+++ b/Demo/Sources/DemosRootViewController.swift
@@ -118,6 +118,20 @@ public final class DemosRootViewController : UIViewController
                         self.push(FlowLayoutViewController())
                 })
             }
+            
+            list += Section(identifier: "table-view") { section in
+                
+                section.header = HeaderFooter(
+                    with: DemoHeader(title: "Table Views")
+                )
+                
+                section += Item(
+                    with: DemoItem(text: "Swipe To Action"),
+                    selection: .isSelectable(isSelected: false),
+                    onSelect : { _ in
+                        self.push(DemoTableViewController())
+                })
+            }
         }
     }
 }

--- a/Demo/Sources/DemosRootViewController.swift
+++ b/Demo/Sources/DemosRootViewController.swift
@@ -128,6 +128,13 @@ public final class DemosRootViewController : UIViewController
                 section += Item(
                     with: DemoItem(text: "Swipe To Action"),
                     selection: .isSelectable(isSelected: false),
+                    swipeActions: SwipeActions(SwipeAction(
+                    title: "Delete",
+                    backgroundColor: .purple,
+                    image: nil, onTap: { _ in
+                        print("Delete")
+                        return true
+                    }), performsFirstOnFullSwipe: true),
                     onSelect : { _ in
                         self.push(DemoTableViewController())
                 })

--- a/Listable/Sources/Internal/DefaultItemElementSwipeActionsAppearance.swift
+++ b/Listable/Sources/Internal/DefaultItemElementSwipeActionsAppearance.swift
@@ -1,0 +1,141 @@
+//
+//  DefaultItemElementSwipeActionsAppearance.swift
+//  AppHost-BlueprintLists-Unit-Tests
+//
+//  Created by Matthew Faluotico on 4/14/20.
+//
+
+import Foundation
+
+public final class DefaultItemElementSwipeActionsAppearance: ItemElementSwipeActionsAppearance {
+
+    public init() { }
+
+}
+
+// MARK: - ItemElementSwipeActionsAppearance
+public extension DefaultItemElementSwipeActionsAppearance {
+
+    static func createView(frame: CGRect) -> SwipeView {
+        return .init()
+    }
+
+    func apply(swipeActions: SwipeActions, to view: SwipeView) {
+        // Currently only supporting first action
+        if let action = swipeActions.actions.first {
+            view.action = action
+        }
+    }
+
+    func apply(swipeControllerState: SwipeControllerState, to view: DefaultItemElementSwipeActionsAppearance.SwipeView) {
+        view.state = swipeControllerState
+    }
+
+    func preferredSize(for view: SwipeView) -> CGSize {
+        return view.preferredSize()
+    }
+
+}
+
+// MARK: - SwipeView
+extension DefaultItemElementSwipeActionsAppearance {
+
+    public final class SwipeView: UIView {
+
+        private static var padding: UIEdgeInsets
+        {
+            return UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        }
+
+        var state: SwipeControllerState
+        {
+            didSet {
+                UIView.animate(withDuration: 0.2) {
+                    switch self.state {
+                    case .pending, .swiping(passedSwipeThroughThreshold: false), .locked:
+                        self.stackView.alignment = .center
+                    case .swiping(passedSwipeThroughThreshold: true), .finished:
+                        self.stackView.alignment = .leading
+                    }
+                }
+            }
+        }
+
+        var action: SwipeAction? {
+            didSet {
+                self.titleView?.text = action?.title
+                self.backgroundColor = action?.backgroundColor ?? .white
+
+                if let image = action?.image {
+                    if let imageView = self.imageView {
+                        imageView.image = image
+                    } else {
+                        let imageView = UIImageView(image: image)
+                        self.stackView.addArrangedSubview(imageView)
+                        self.imageView = imageView
+                    }
+                }
+            }
+        }
+
+        private var imageView: UIImageView?
+        private var titleView: UILabel?
+        private var gestureRecognizer: UITapGestureRecognizer
+        private var stackView = UIStackView()
+
+        init()
+        {
+            self.state = .pending
+            self.gestureRecognizer = UITapGestureRecognizer()
+            super.init(frame: .zero)
+
+            self.gestureRecognizer.addTarget(self, action: #selector(onTap))
+            self.addGestureRecognizer(gestureRecognizer)
+
+            let titleView = UILabel()
+            titleView.textColor = .white
+            titleView.lineBreakMode = .byClipping
+            self.stackView.addArrangedSubview(titleView)
+            self.titleView = titleView
+
+            stackView.spacing = 2
+            stackView.alignment = .center
+            stackView.axis = .vertical
+            stackView.distribution = .fill
+            stackView.isLayoutMarginsRelativeArrangement = true
+            stackView.layoutMargins = SwipeView.padding
+
+            self.addSubview(self.stackView)
+        }
+
+        required init?(coder: NSCoder)
+        {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        public override func layoutSubviews()
+        {
+            super.layoutSubviews()
+            self.stackView.frame = self.bounds
+        }
+
+        func preferredSize() -> CGSize
+        {
+            guard let titleView = self.titleView else {
+                return self.sizeThatFits(UIScreen.main.bounds.size)
+            }
+
+            var size = titleView.sizeThatFits(self.bounds.size)
+            size.width += SwipeView.padding.left + SwipeView.padding.right
+            return size
+        }
+
+        @objc func onTap()
+        {
+            if let action = self.action {
+                let _ = action.onTap(action)
+            }
+        }
+    }
+
+}

--- a/Listable/Sources/Internal/ItemElementCell.ContentView.swift
+++ b/Listable/Sources/Internal/ItemElementCell.ContentView.swift
@@ -1,0 +1,45 @@
+//
+//  ItemCellView.swift
+//  Listable
+//
+//  Created by Kyle Van Essen on 3/23/20.
+//
+
+import UIKit
+
+
+extension ItemElementCell
+{
+    final class ContentView : UIView
+    {
+        private(set) var contentScrollView : UIScrollView
+        
+        private(set) var contentView : Element.Appearance.ContentView
+        
+        private(set) var swipeView : Element.SwipeActionsAppearance.ContentView
+        
+        override init(frame : CGRect)
+        {
+            let bounds = CGRect(origin: .zero, size: frame.size)
+            
+            self.contentView = Element.Appearance.createReusableItemView(frame: bounds)
+            self.swipeView = Element.SwipeActionsAppearance.createView(frame: bounds)
+            
+            self.contentScrollView = UIScrollView()
+            
+            super.init(frame: frame)
+            
+            self.addSubview(self.contentView)
+        }
+        
+        @available(*, unavailable)
+        required init?(coder: NSCoder) { fatalError() }
+        
+        override func layoutSubviews()
+        {
+            super.layoutSubviews()
+            
+            self.contentView.frame = self.bounds
+        }
+    }
+}

--- a/Listable/Sources/Internal/ItemElementCell.ContentView.swift
+++ b/Listable/Sources/Internal/ItemElementCell.ContentView.swift
@@ -10,36 +10,401 @@ import UIKit
 
 extension ItemElementCell
 {
-    final class ContentView : UIView
+    final class ContentView : UIView, SwipeControllerDelegate
     {
-        private(set) var contentScrollView : UIScrollView
-        
         private(set) var contentView : Element.Appearance.ContentView
-        
-        private(set) var swipeView : Element.SwipeActionsAppearance.ContentView
-        
+
+        private var swipeController: SwipeController?
+        private var swipeView : SwipeController.SwipeView?
+
         override init(frame : CGRect)
         {
             let bounds = CGRect(origin: .zero, size: frame.size)
-            
+
             self.contentView = Element.Appearance.createReusableItemView(frame: bounds)
-            self.swipeView = Element.SwipeActionsAppearance.createView(frame: bounds)
-            
-            self.contentScrollView = UIScrollView()
-            
+
             super.init(frame: frame)
-            
+
             self.addSubview(self.contentView)
         }
-        
+
         @available(*, unavailable)
         required init?(coder: NSCoder) { fatalError() }
-        
+
         override func layoutSubviews()
         {
             super.layoutSubviews()
-            
-            self.contentView.frame = self.bounds
+
+            guard let swipeController = self.swipeController, let swipeView = self.swipeView else {
+                contentView.frame = self.bounds
+                return
+            }
+
+            // Set frames if swiping is supported
+
+            switch swipeController.state {
+
+            case .pending:
+                self.setFrames(newOrigin: 0)
+
+            case .locked:
+                let lowerThreshold = swipeView.preferredSize().width
+                self.setFrames(newOrigin: -lowerThreshold)
+
+            case .finished:
+                let end = self.bounds.width
+                self.setFrames(newOrigin: -end)
+
+            case .swiping(swipeThrough: _):
+                let newOrigin = swipeController.calculateNewOrigin(clearTranslation: true)
+                self.setFrames(newOrigin: newOrigin.x)
+            }
+
+        }
+
+        // MARK: - Swipe
+
+        public func restoreSwipe()
+        {
+            swipeController = nil
+            swipeView?.removeFromSuperview()
+            swipeView = nil
+        }
+
+        public func prepareForSwipeActions(actions: SwipeActions)
+        {
+            guard self.swipeController == nil else { return }
+
+            let swipeView = SwipeController.SwipeView(action: actions.actions.first!)
+
+            let swipeController = SwipeController(
+                actions: actions,
+                contentView: self.contentView,
+                containerView: self,
+                swipeView: swipeView
+            )
+
+            swipeController.configure()
+            swipeController.delegate = self
+
+            self.insertSubview(swipeView, belowSubview: self.contentView)
+
+            self.swipeController = swipeController
+            self.swipeView = swipeView
+
+            self.setNeedsLayout()
+            self.layoutIfNeeded()
+        }
+
+        private func setFrames(newOrigin: CGFloat)
+        {
+            let width = self.bounds.width
+            var frame = self.contentView.frame
+            frame.origin.x = newOrigin
+            self.contentView.frame = frame
+
+            let originX = frame.maxX
+            let swipeWidth = width - originX
+
+            self.swipeView?.frame = CGRect(
+                x: originX,
+                y: frame.origin.y,
+                width: swipeWidth,
+                height: frame.height
+            )
+        }
+
+        // MARK: - Swipe Controller Delegate
+
+        func swipeController(panDidMove controller: SwipeController)
+        {
+            self.setNeedsLayout()
+            self.layoutIfNeeded()
+        }
+
+        func swipeController(panDidEnd controller: SwipeController)
+        {
+            UIView.animate(withDuration: 0.2) {
+                self.setNeedsLayout()
+                self.layoutIfNeeded()
+            }
         }
     }
+}
+
+protocol SwipeControllerDelegate: class {
+
+    func swipeController(panDidMove controller: SwipeController)
+    func swipeController(panDidEnd controller: SwipeController)
+
+}
+
+class SwipeController: NSObject {
+
+    enum State {
+        case pending
+        case swiping(swipeThrough: Bool)
+        case locked
+        case finished
+    }
+
+    var state: State = .pending {
+        didSet {
+            self.swipeView?.state = state
+        }
+    }
+
+    var actions: SwipeActions
+    weak var swipeView: SwipeView?
+    weak var contentView: UIView?
+    weak var containerView: UIView?
+
+    weak var collectionView: UICollectionView?
+
+    weak var delegate: SwipeControllerDelegate?
+
+    private(set) var gestureRecognizer: UIPanGestureRecognizer
+
+    init(
+        actions: SwipeActions,
+        contentView: UIView,
+        containerView: UIView,
+        swipeView: SwipeView)
+    {
+        self.actions = actions
+        self.contentView = contentView
+        self.containerView = containerView
+        self.gestureRecognizer = UIPanGestureRecognizer()
+        self.swipeView = swipeView
+
+        super.init()
+    }
+
+    func configure()
+    {
+        gestureRecognizer.addTarget(self, action: #selector(onPan(_:)))
+        containerView?.addGestureRecognizer(self.gestureRecognizer)
+    }
+
+    deinit
+    {
+        self.containerView?.removeGestureRecognizer(self.gestureRecognizer)
+    }
+
+    func performSwipeThroughAction()
+    {
+        if let action = actions.actions.first {
+            let _ = action.onTap(action)
+        }
+    }
+
+    @objc func onPan(_ pan: UIPanGestureRecognizer)
+    {
+        switch pan.state {
+        case .began:
+            guard let collectionView = SwipeController.findCollectionView(child: containerView), self.collectionView == nil else { return }
+            collectionView.panGestureRecognizer.addTarget(self, action: #selector(collectionViewPan))
+            self.collectionView = collectionView
+        case .changed:
+            panChanged(pan)
+        case .failed, .cancelled, .ended:
+            panEnded(pan)
+        default:
+            break
+        }
+    }
+
+    private func panChanged(_ pan: UIPanGestureRecognizer)
+    {
+        let originInContainer = self.calculateNewOrigin()
+        self.state = self.panningState(originInContainer: originInContainer)
+
+        self.delegate?.swipeController(panDidMove: self)
+    }
+
+    private func panEnded(_ pan: UIPanGestureRecognizer)
+    {
+        let originInContainer = self.calculateNewOrigin()
+        self.state = self.endState(originInContainer: originInContainer)
+
+        self.delegate?.swipeController(panDidEnd: self)
+
+        if case .finished = self.state, self.swipeThroughEnabled {
+            self.performSwipeThroughAction()
+        }
+    }
+
+    //
+
+    private func panningState(originInContainer: CGPoint) -> State
+    {
+        if originInContainer.x > 0 {
+            return .pending
+        } else
+            if originInContainer.x < self.swipeThroughOriginX && self.swipeThroughEnabled {
+            return .swiping(swipeThrough: true)
+        } else {
+            return .swiping(swipeThrough: false)
+        }
+    }
+
+    private func endState(originInContainer: CGPoint) -> State
+    {
+        guard let swipeView = self.swipeView else { fatalError() }
+
+        let holdXPosition = -swipeView.preferredSize().width
+
+        if originInContainer.x < self.swipeThroughOriginX && self.swipeThroughEnabled  {
+            return .finished
+        } else if originInContainer.x < holdXPosition {
+            return .locked
+        } else {
+            return .pending
+        }
+
+    }
+
+    // - UICollectionView
+
+    @objc func collectionViewPan()
+    {
+        self.state = .pending
+        self.delegate?.swipeController(panDidEnd: self)
+        self.collectionView?.panGestureRecognizer.removeTarget(self, action: nil)
+        self.collectionView = nil
+    }
+
+    // - Helpers
+
+    func calculateNewOrigin(clearTranslation: Bool = false) -> CGPoint
+    {
+        let translationInContainer: CGPoint = self.gestureRecognizer.translation(in: containerView!)
+        // TODO Factor in Velocity
+        let oldPoint = self.contentView!.frame.origin.x
+        if clearTranslation {
+            self.gestureRecognizer.setTranslation(.zero, in: containerView!)
+        }
+
+        return CGPoint(x: oldPoint + translationInContainer.x, y: 0)
+    }
+
+    var swipeThroughEnabled: Bool
+    {
+        return actions.performsFirstOnFullSwipe
+    }
+
+    private var swipeThroughOriginX: CGFloat
+    {
+        guard let containerView = self.containerView else { fatalError() }
+        return -(containerView.bounds.width * 0.6)
+    }
+
+    private static func findCollectionView(child: UIView?) -> UICollectionView?
+    {
+        var view: UIView? = child
+
+        while view != nil {
+            if let collectionView = view as? UICollectionView {
+                return collectionView
+            } else {
+                view = view?.superview
+            }
+        }
+
+        return nil
+
+    }
+}
+
+extension SwipeController {
+
+    class SwipeView: UIView {
+
+        private static var padding: UIEdgeInsets
+        {
+            return UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        }
+
+        var state: SwipeController.State
+        {
+            didSet {
+                UIView.animate(withDuration: 0.2) {
+                    switch self.state {
+                    case .pending, .swiping(swipeThrough: false), .locked:
+                        self.stackView.alignment = .center
+                    case .swiping(swipeThrough: true), .finished:
+                        self.stackView.alignment = .leading
+                    }
+                }
+            }
+        }
+
+        private var action: SwipeAction
+
+        private var imageView: UIImageView?
+        private var titleView: UILabel!
+        private var gestureRecognizer: UITapGestureRecognizer!
+        private var stackView = UIStackView()
+
+        init(action: SwipeAction)
+        {
+            self.action = action
+            self.state = .pending
+            super.init(frame: .zero)
+
+            let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTap))
+            self.addGestureRecognizer(gestureRecognizer)
+            self.gestureRecognizer = gestureRecognizer
+
+            self.backgroundColor = action.backgroundColor ?? .red
+
+            if let title = action.title {
+                let titleView = UILabel()
+                titleView.text = title
+                titleView.textColor = .white
+                titleView.lineBreakMode = .byClipping
+                self.stackView.addArrangedSubview(titleView)
+                self.titleView = titleView
+            }
+
+            if let image = action.image {
+                let imageView = UIImageView(image: image)
+                self.stackView.addArrangedSubview(imageView)
+                self.imageView = imageView
+            }
+
+            stackView.spacing = 2
+            stackView.alignment = .center
+            stackView.axis = .vertical
+            stackView.distribution = .fill
+            stackView.isLayoutMarginsRelativeArrangement = true
+            stackView.layoutMargins = SwipeView.padding
+
+            self.addSubview(self.stackView)
+        }
+
+        required init?(coder: NSCoder)
+        {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layoutSubviews()
+        {
+            super.layoutSubviews()
+            self.stackView.frame = self.bounds
+        }
+
+        func preferredSize() -> CGSize
+        {
+            var size = self.titleView.sizeThatFits(self.bounds.size)
+            size.width += SwipeView.padding.left + SwipeView.padding.right
+            return size
+        }
+
+        @objc func onTap()
+        {
+            let _ = self.action.onTap(action)
+        }
+    }
+
 }

--- a/Listable/Sources/Internal/ItemElementCell.ContentView.swift
+++ b/Listable/Sources/Internal/ItemElementCell.ContentView.swift
@@ -35,45 +35,64 @@ extension ItemElementCell
         {
             super.layoutSubviews()
 
-            guard let swipeController = self.swipeController, let swipeView = self.swipeView else {
+            if let swipeController = self.swipeController, let swipeView = self.swipeView {
+                self.setFrames(swipeController: swipeController, swipeView: swipeView)
+            } else {
                 contentView.frame = self.bounds
-                return
             }
+        }
 
-            // Set frames if swiping is supported
+        /// Set frames when swipe controller is active
+        private func setFrames(swipeController: SwipeController, swipeView: SwipeController.SwipeView)
+        {
+            let newOrigin_x: CGFloat
 
             switch swipeController.state {
-
             case .pending:
-                self.setFrames(newOrigin: 0)
+                newOrigin_x = 0
 
             case .locked:
                 let lowerThreshold = swipeView.preferredSize().width
-                self.setFrames(newOrigin: -lowerThreshold)
+                newOrigin_x = -lowerThreshold
 
             case .finished:
                 let end = self.bounds.width
-                self.setFrames(newOrigin: -end)
+                newOrigin_x = -end
 
             case .swiping(swipeThrough: _):
-                let newOrigin = swipeController.calculateNewOrigin(clearTranslation: true)
-                self.setFrames(newOrigin: newOrigin.x)
+                newOrigin_x = swipeController.calculateNewOrigin(clearTranslation: true).x
             }
 
+            let width = self.bounds.width
+            var frame = self.contentView.frame
+            frame.origin.x = newOrigin_x
+            self.contentView.frame = frame
+
+            let originX = frame.maxX
+            let swipeWidth = width - originX
+
+            self.swipeView?.frame = CGRect(
+                x: originX,
+                y: frame.origin.y,
+                width: swipeWidth,
+                height: frame.height
+            )
         }
 
-        // MARK: - Swipe
+        // MARK: - Swipe Registration
 
-        public func restoreSwipe()
+        public func deregisterSwipeIfNeeded()
         {
+            guard swipeController != nil else { return }
+
             swipeController = nil
             swipeView?.removeFromSuperview()
             swipeView = nil
         }
 
-        public func prepareForSwipeActions(actions: SwipeActions)
+        public func registerSwipeActionsIfNeeded(actions: SwipeActions)
         {
-            guard self.swipeController == nil else { return }
+            guard self.swipeController == nil else { return } // Already Registered
 
             let swipeView = SwipeController.SwipeView(action: actions.actions.first!)
 
@@ -96,24 +115,6 @@ extension ItemElementCell
             self.layoutIfNeeded()
         }
 
-        private func setFrames(newOrigin: CGFloat)
-        {
-            let width = self.bounds.width
-            var frame = self.contentView.frame
-            frame.origin.x = newOrigin
-            self.contentView.frame = frame
-
-            let originX = frame.maxX
-            let swipeWidth = width - originX
-
-            self.swipeView?.frame = CGRect(
-                x: originX,
-                y: frame.origin.y,
-                width: swipeWidth,
-                height: frame.height
-            )
-        }
-
         // MARK: - Swipe Controller Delegate
 
         func swipeController(panDidMove controller: SwipeController)
@@ -132,279 +133,3 @@ extension ItemElementCell
     }
 }
 
-protocol SwipeControllerDelegate: class {
-
-    func swipeController(panDidMove controller: SwipeController)
-    func swipeController(panDidEnd controller: SwipeController)
-
-}
-
-class SwipeController: NSObject {
-
-    enum State {
-        case pending
-        case swiping(swipeThrough: Bool)
-        case locked
-        case finished
-    }
-
-    var state: State = .pending {
-        didSet {
-            self.swipeView?.state = state
-        }
-    }
-
-    var actions: SwipeActions
-    weak var swipeView: SwipeView?
-    weak var contentView: UIView?
-    weak var containerView: UIView?
-
-    weak var collectionView: UICollectionView?
-
-    weak var delegate: SwipeControllerDelegate?
-
-    private(set) var gestureRecognizer: UIPanGestureRecognizer
-
-    init(
-        actions: SwipeActions,
-        contentView: UIView,
-        containerView: UIView,
-        swipeView: SwipeView)
-    {
-        self.actions = actions
-        self.contentView = contentView
-        self.containerView = containerView
-        self.gestureRecognizer = UIPanGestureRecognizer()
-        self.swipeView = swipeView
-
-        super.init()
-    }
-
-    func configure()
-    {
-        gestureRecognizer.addTarget(self, action: #selector(onPan(_:)))
-        containerView?.addGestureRecognizer(self.gestureRecognizer)
-    }
-
-    deinit
-    {
-        self.containerView?.removeGestureRecognizer(self.gestureRecognizer)
-    }
-
-    func performSwipeThroughAction()
-    {
-        if let action = actions.actions.first {
-            let _ = action.onTap(action)
-        }
-    }
-
-    @objc func onPan(_ pan: UIPanGestureRecognizer)
-    {
-        switch pan.state {
-        case .began:
-            guard let collectionView = SwipeController.findCollectionView(child: containerView), self.collectionView == nil else { return }
-            collectionView.panGestureRecognizer.addTarget(self, action: #selector(collectionViewPan))
-            self.collectionView = collectionView
-        case .changed:
-            panChanged(pan)
-        case .failed, .cancelled, .ended:
-            panEnded(pan)
-        default:
-            break
-        }
-    }
-
-    private func panChanged(_ pan: UIPanGestureRecognizer)
-    {
-        let originInContainer = self.calculateNewOrigin()
-        self.state = self.panningState(originInContainer: originInContainer)
-
-        self.delegate?.swipeController(panDidMove: self)
-    }
-
-    private func panEnded(_ pan: UIPanGestureRecognizer)
-    {
-        let originInContainer = self.calculateNewOrigin()
-        self.state = self.endState(originInContainer: originInContainer)
-
-        self.delegate?.swipeController(panDidEnd: self)
-
-        if case .finished = self.state, self.swipeThroughEnabled {
-            self.performSwipeThroughAction()
-        }
-    }
-
-    //
-
-    private func panningState(originInContainer: CGPoint) -> State
-    {
-        if originInContainer.x > 0 {
-            return .pending
-        } else
-            if originInContainer.x < self.swipeThroughOriginX && self.swipeThroughEnabled {
-            return .swiping(swipeThrough: true)
-        } else {
-            return .swiping(swipeThrough: false)
-        }
-    }
-
-    private func endState(originInContainer: CGPoint) -> State
-    {
-        guard let swipeView = self.swipeView else { fatalError() }
-
-        let holdXPosition = -swipeView.preferredSize().width
-
-        if originInContainer.x < self.swipeThroughOriginX && self.swipeThroughEnabled  {
-            return .finished
-        } else if originInContainer.x < holdXPosition {
-            return .locked
-        } else {
-            return .pending
-        }
-
-    }
-
-    // - UICollectionView
-
-    @objc func collectionViewPan()
-    {
-        self.state = .pending
-        self.delegate?.swipeController(panDidEnd: self)
-        self.collectionView?.panGestureRecognizer.removeTarget(self, action: nil)
-        self.collectionView = nil
-    }
-
-    // - Helpers
-
-    func calculateNewOrigin(clearTranslation: Bool = false) -> CGPoint
-    {
-        let translationInContainer: CGPoint = self.gestureRecognizer.translation(in: containerView!)
-        // TODO Factor in Velocity
-        let oldPoint = self.contentView!.frame.origin.x
-        if clearTranslation {
-            self.gestureRecognizer.setTranslation(.zero, in: containerView!)
-        }
-
-        return CGPoint(x: oldPoint + translationInContainer.x, y: 0)
-    }
-
-    var swipeThroughEnabled: Bool
-    {
-        return actions.performsFirstOnFullSwipe
-    }
-
-    private var swipeThroughOriginX: CGFloat
-    {
-        guard let containerView = self.containerView else { fatalError() }
-        return -(containerView.bounds.width * 0.6)
-    }
-
-    private static func findCollectionView(child: UIView?) -> UICollectionView?
-    {
-        var view: UIView? = child
-
-        while view != nil {
-            if let collectionView = view as? UICollectionView {
-                return collectionView
-            } else {
-                view = view?.superview
-            }
-        }
-
-        return nil
-
-    }
-}
-
-extension SwipeController {
-
-    class SwipeView: UIView {
-
-        private static var padding: UIEdgeInsets
-        {
-            return UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        }
-
-        var state: SwipeController.State
-        {
-            didSet {
-                UIView.animate(withDuration: 0.2) {
-                    switch self.state {
-                    case .pending, .swiping(swipeThrough: false), .locked:
-                        self.stackView.alignment = .center
-                    case .swiping(swipeThrough: true), .finished:
-                        self.stackView.alignment = .leading
-                    }
-                }
-            }
-        }
-
-        private var action: SwipeAction
-
-        private var imageView: UIImageView?
-        private var titleView: UILabel!
-        private var gestureRecognizer: UITapGestureRecognizer!
-        private var stackView = UIStackView()
-
-        init(action: SwipeAction)
-        {
-            self.action = action
-            self.state = .pending
-            super.init(frame: .zero)
-
-            let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTap))
-            self.addGestureRecognizer(gestureRecognizer)
-            self.gestureRecognizer = gestureRecognizer
-
-            self.backgroundColor = action.backgroundColor ?? .red
-
-            if let title = action.title {
-                let titleView = UILabel()
-                titleView.text = title
-                titleView.textColor = .white
-                titleView.lineBreakMode = .byClipping
-                self.stackView.addArrangedSubview(titleView)
-                self.titleView = titleView
-            }
-
-            if let image = action.image {
-                let imageView = UIImageView(image: image)
-                self.stackView.addArrangedSubview(imageView)
-                self.imageView = imageView
-            }
-
-            stackView.spacing = 2
-            stackView.alignment = .center
-            stackView.axis = .vertical
-            stackView.distribution = .fill
-            stackView.isLayoutMarginsRelativeArrangement = true
-            stackView.layoutMargins = SwipeView.padding
-
-            self.addSubview(self.stackView)
-        }
-
-        required init?(coder: NSCoder)
-        {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        override func layoutSubviews()
-        {
-            super.layoutSubviews()
-            self.stackView.frame = self.bounds
-        }
-
-        func preferredSize() -> CGSize
-        {
-            var size = self.titleView.sizeThatFits(self.bounds.size)
-            size.width += SwipeView.padding.left + SwipeView.padding.right
-            return size
-        }
-
-        @objc func onTap()
-        {
-            let _ = self.action.onTap(action)
-        }
-    }
-
-}

--- a/Listable/Sources/Internal/ItemElementCell.ContentView.swift
+++ b/Listable/Sources/Internal/ItemElementCell.ContentView.swift
@@ -14,8 +14,8 @@ extension ItemElementCell
     {
         private(set) var contentView : Element.Appearance.ContentView
 
-        private var swipeController: SwipeController?
-        private var swipeView : SwipeController.SwipeView?
+        private var swipeController: SwipeController<Element.SwipeActionsAppearance>?
+        private(set) var swipeView : Element.SwipeActionsAppearance.ContentView?
 
         override init(frame : CGRect)
         {
@@ -43,7 +43,7 @@ extension ItemElementCell
         }
 
         /// Set frames when swipe controller is active
-        private func setFrames(swipeController: SwipeController, swipeView: SwipeController.SwipeView)
+        private func setFrames(swipeController: SwipeController<Element.SwipeActionsAppearance>, swipeView: Element.SwipeActionsAppearance.ContentView)
         {
             let newOrigin_x: CGFloat
 
@@ -52,14 +52,14 @@ extension ItemElementCell
                 newOrigin_x = 0
 
             case .locked:
-                let lowerThreshold = swipeView.preferredSize().width
+                let lowerThreshold = swipeController.appearance.preferredSize(for: swipeView).width
                 newOrigin_x = -lowerThreshold
 
             case .finished:
                 let end = self.bounds.width
                 newOrigin_x = -end
 
-            case .swiping(swipeThrough: _):
+            case .swiping(passedSwipeThroughThreshold: _):
                 newOrigin_x = swipeController.calculateNewOrigin(clearTranslation: true).x
             }
 
@@ -90,17 +90,18 @@ extension ItemElementCell
             swipeView = nil
         }
 
-        public func registerSwipeActionsIfNeeded(actions: SwipeActions)
+        public func registerSwipeActionsIfNeeded(actions: SwipeActions, appearance: Element.SwipeActionsAppearance)
         {
             guard self.swipeController == nil else { return } // Already Registered
 
-            let swipeView = SwipeController.SwipeView(action: actions.actions.first!)
+            let swipeView = Element.SwipeActionsAppearance.createView(frame: .zero)
 
-            let swipeController = SwipeController(
+            let swipeController = SwipeController<Element.SwipeActionsAppearance>(
+                appearance: appearance,
+                swipeView: swipeView,
                 actions: actions,
                 contentView: self.contentView,
-                containerView: self,
-                swipeView: swipeView
+                containerView: self
             )
 
             swipeController.configure()
@@ -113,17 +114,19 @@ extension ItemElementCell
 
             self.setNeedsLayout()
             self.layoutIfNeeded()
+
+            appearance.apply(swipeActions: actions, to: swipeView)
         }
 
         // MARK: - Swipe Controller Delegate
 
-        func swipeController(panDidMove controller: SwipeController)
+        func swipeControllerPanDidMove()
         {
             self.setNeedsLayout()
             self.layoutIfNeeded()
         }
 
-        func swipeController(panDidEnd controller: SwipeController)
+        func swipeControllerPanDidEnd()
         {
             UIView.animate(withDuration: 0.2) {
                 self.setNeedsLayout()

--- a/Listable/Sources/Internal/ItemElementCell.ContentViewContainer.swift
+++ b/Listable/Sources/Internal/ItemElementCell.ContentViewContainer.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension ItemElementCell
 {
-    final class ContentView : UIView, SwipeControllerDelegate
+    final class ContentContainerView : UIView, SwipeControllerDelegate
     {
         private(set) var contentView : Element.Appearance.ContentView
 
@@ -48,10 +48,10 @@ extension ItemElementCell
             let newOrigin_x: CGFloat
 
             switch swipeController.state {
-            case .pending:
+            case .closed:
                 newOrigin_x = 0
 
-            case .locked:
+            case .open:
                 let lowerThreshold = swipeController.appearance.preferredSize(for: swipeView).width
                 newOrigin_x = -lowerThreshold
 
@@ -92,8 +92,14 @@ extension ItemElementCell
 
         public func registerSwipeActionsIfNeeded(actions: SwipeActions, appearance: Element.SwipeActionsAppearance)
         {
-            guard self.swipeController == nil else { return } // Already Registered
+            // Update if already initialized
+            if let swipeController = self.swipeController, let swipeView = self.swipeView {
+                swipeController.actions = actions
+                appearance.apply(swipeActions: actions, to: swipeView)
+                return
+            }
 
+            // Follow through with initialization
             let swipeView = Element.SwipeActionsAppearance.createView(frame: .zero)
 
             let swipeController = SwipeController<Element.SwipeActionsAppearance>(
@@ -111,9 +117,6 @@ extension ItemElementCell
 
             self.swipeController = swipeController
             self.swipeView = swipeView
-
-            self.setNeedsLayout()
-            self.layoutIfNeeded()
 
             appearance.apply(swipeActions: actions, to: swipeView)
         }

--- a/Listable/Sources/Internal/ItemElementCell.swift
+++ b/Listable/Sources/Internal/ItemElementCell.swift
@@ -10,13 +10,13 @@ import UIKit
 
 final class ItemElementCell<Element:ItemElement> : UICollectionViewCell
 {
-    let content : ContentView
+    let content : ContentContainerView
         
     override init(frame: CGRect)
     {
         let bounds = CGRect(origin: .zero, size: frame.size)
         
-        self.content = ContentView(frame: bounds)
+        self.content = ContentContainerView(frame: bounds)
         
         super.init(frame: frame)
         

--- a/Listable/Sources/Internal/ItemElementCell.swift
+++ b/Listable/Sources/Internal/ItemElementCell.swift
@@ -10,11 +10,13 @@ import UIKit
 
 final class ItemElementCell<Element:ItemElement> : UICollectionViewCell
 {
-    let content : Element.Appearance.ContentView
+    let content : ContentView
         
     override init(frame: CGRect)
     {
-        self.content = Element.Appearance.createReusableItemView(frame: frame)
+        let bounds = CGRect(origin: .zero, size: frame.size)
+        
+        self.content = ContentView(frame: bounds)
         
         super.init(frame: frame)
         

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -656,8 +656,8 @@ final class PresentationState
             
             // Apply Swipe To Action Appearance
             
-            if let actions = self.model.swipeActions {
-                cell.content.registerSwipeActionsIfNeeded(actions: actions)
+            if let actions = self.model.swipeActions, let appearance = self.model.swipeActionsAppearance {
+                cell.content.registerSwipeActionsIfNeeded(actions: actions, appearance: appearance)
             } else {
                 cell.content.deregisterSwipeIfNeeded()
             }

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -655,7 +655,6 @@ final class PresentationState
             )
             
             // Apply Swipe To Action Appearance
-            
             if let actions = self.model.swipeActions, let appearance = self.model.swipeActionsAppearance {
                 cell.content.registerSwipeActionsIfNeeded(actions: actions, appearance: appearance)
             } else {

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -464,6 +464,8 @@ final class PresentationState
         {
             let view = view as! Element.Appearance.ContentView
             
+            // TODO: Merge this with the other place we apply to views.
+            
             self.model.appearance.apply(to: view)
             self.model.element.apply(to: view, reason: reason)
         }
@@ -561,7 +563,7 @@ final class PresentationState
                         )
                         
                         self.model.element.apply(
-                            to: cell.content,
+                            to: cell.content.contentView,
                             for: .wasUpdated,
                             with: applyInfo
                         )
@@ -640,17 +642,29 @@ final class PresentationState
             // Appearance
             
             self.model.appearance.apply(
-                to: cell.content,
+                to: cell.content.contentView,
                 with: applyInfo
             )
             
             // Apply Model State
             
             self.model.element.apply(
-                to: cell.content,
+                to: cell.content.contentView,
                 for: reason,
                 with: applyInfo
             )
+            
+            // Apply Swipe To Action Appearance
+            
+            if
+                let actions = self.model.swipeActions,
+                let appearance = self.model.swipeActionsAppearance
+            {
+                appearance.apply(
+                    swipeActions: actions,
+                    to: cell.content.swipeView
+                )
+            }
         }
         
         func applyToVisibleCell()

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -656,14 +656,9 @@ final class PresentationState
             
             // Apply Swipe To Action Appearance
             
-            if
-                let actions = self.model.swipeActions,
-                let appearance = self.model.swipeActionsAppearance
+            if let actions = self.model.swipeActions
             {
-                appearance.apply(
-                    swipeActions: actions,
-                    to: cell.content.swipeView
-                )
+                cell.content.prepareForSwipeActions(actions: actions)
             }
         }
         

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -656,9 +656,10 @@ final class PresentationState
             
             // Apply Swipe To Action Appearance
             
-            if let actions = self.model.swipeActions
-            {
-                cell.content.prepareForSwipeActions(actions: actions)
+            if let actions = self.model.swipeActions {
+                cell.content.registerSwipeActionsIfNeeded(actions: actions)
+            } else {
+                cell.content.deregisterSwipeIfNeeded()
             }
         }
         

--- a/Listable/Sources/Internal/SwipeController.swift
+++ b/Listable/Sources/Internal/SwipeController.swift
@@ -1,0 +1,285 @@
+//
+//  SwipeController.swift
+//  Listable
+//
+//  Created by Matthew Faluotico on 4/3/20.
+//
+
+import Foundation
+
+protocol SwipeControllerDelegate: class {
+
+    func swipeController(panDidMove controller: SwipeController)
+    func swipeController(panDidEnd controller: SwipeController)
+
+}
+
+class SwipeController: NSObject {
+
+    enum State {
+        case pending
+        case swiping(swipeThrough: Bool)
+        case locked
+        case finished
+    }
+
+    var state: State = .pending {
+        didSet {
+            self.swipeView?.state = state
+        }
+    }
+
+    var actions: SwipeActions
+
+    weak var swipeView: SwipeView?
+    weak var contentView: UIView?
+    weak var containerView: UIView?
+    weak var delegate: SwipeControllerDelegate?
+
+    private weak var collectionView: UICollectionView?
+
+    private(set) var gestureRecognizer: UIPanGestureRecognizer
+
+    init(
+        actions: SwipeActions,
+        contentView: UIView,
+        containerView: UIView,
+        swipeView: SwipeView)
+    {
+        self.actions = actions
+        self.contentView = contentView
+        self.containerView = containerView
+        self.gestureRecognizer = UIPanGestureRecognizer()
+        self.swipeView = swipeView
+
+        super.init()
+    }
+
+    func configure()
+    {
+        gestureRecognizer.addTarget(self, action: #selector(onPan(_:)))
+        containerView?.addGestureRecognizer(gestureRecognizer)
+    }
+
+    deinit
+    {
+        containerView?.removeGestureRecognizer(self.gestureRecognizer)
+    }
+
+    func performSwipeThroughAction()
+    {
+        if let action = actions.actions.first {
+            let _ = action.onTap(action)
+        }
+    }
+
+    // MARK: - Panning
+
+    @objc func onPan(_ pan: UIPanGestureRecognizer)
+    {
+        switch pan.state {
+        case .began:
+            guard let collectionView = SwipeController.findCollectionView(child: containerView), self.collectionView == nil else { return }
+            collectionView.panGestureRecognizer.addTarget(self, action: #selector(collectionViewPan))
+            self.collectionView = collectionView
+        case .changed:
+            panChanged(pan)
+        case .failed, .cancelled, .ended:
+            panEnded(pan)
+        default:
+            break
+        }
+    }
+
+    private func panChanged(_ pan: UIPanGestureRecognizer)
+    {
+        let originInContainer = calculateNewOrigin()
+        state = panningState(originInContainer: originInContainer)
+
+        delegate?.swipeController(panDidMove: self)
+    }
+
+    private func panEnded(_ pan: UIPanGestureRecognizer)
+    {
+        let originInContainer = calculateNewOrigin()
+        state = endState(originInContainer: originInContainer)
+
+        delegate?.swipeController(panDidEnd: self)
+
+        if case .finished = state, swipeThroughEnabled {
+            self.performSwipeThroughAction()
+        }
+    }
+
+    private func panningState(originInContainer: CGPoint) -> State
+    {
+        if originInContainer.x > 0 {
+            return .pending
+        } else
+            if originInContainer.x < self.swipeThroughOriginX && self.swipeThroughEnabled {
+            return .swiping(swipeThrough: true)
+        } else {
+            return .swiping(swipeThrough: false)
+        }
+    }
+
+    private func endState(originInContainer: CGPoint) -> State
+    {
+        guard let swipeView = swipeView else { fatalError() }
+
+        let holdXPosition = -swipeView.preferredSize().width
+
+        if originInContainer.x < swipeThroughOriginX && swipeThroughEnabled  {
+            return .finished
+        } else if originInContainer.x < holdXPosition {
+            return .locked
+        } else {
+            return .pending
+        }
+
+    }
+
+    // MARK: - UICollectionView
+
+    @objc func collectionViewPan()
+    {
+        self.state = .pending
+        self.delegate?.swipeController(panDidEnd: self)
+        self.collectionView?.panGestureRecognizer.removeTarget(self, action: nil)
+        self.collectionView = nil
+    }
+
+    // ARK: - Helpers
+
+    func calculateNewOrigin(clearTranslation: Bool = false) -> CGPoint
+    {
+        let translationInContainer: CGPoint = gestureRecognizer.translation(in: containerView!)
+        // TODO Factor in Velocity
+        let oldPoint = contentView!.frame.origin.x
+        if clearTranslation {
+            gestureRecognizer.setTranslation(.zero, in: containerView!)
+        }
+
+        return CGPoint(x: oldPoint + translationInContainer.x, y: 0)
+    }
+
+    var swipeThroughEnabled: Bool
+    {
+        return actions.performsFirstOnFullSwipe
+    }
+
+    private var swipeThroughOriginX: CGFloat
+    {
+        guard let containerView = containerView else { fatalError() }
+        return -(containerView.bounds.width * 0.6)
+    }
+
+    private static func findCollectionView(child: UIView?) -> UICollectionView?
+    {
+        var view: UIView? = child
+
+        while view != nil {
+            if let collectionView = view as? UICollectionView {
+                return collectionView
+            } else {
+                view = view?.superview
+            }
+        }
+
+        return nil
+
+    }
+}
+
+extension SwipeController {
+
+    class SwipeView: UIView {
+
+        private static var padding: UIEdgeInsets
+        {
+            return UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        }
+
+        var state: SwipeController.State
+        {
+            didSet {
+                UIView.animate(withDuration: 0.2) {
+                    switch self.state {
+                    case .pending, .swiping(swipeThrough: false), .locked:
+                        self.stackView.alignment = .center
+                    case .swiping(swipeThrough: true), .finished:
+                        self.stackView.alignment = .leading
+                    }
+                }
+            }
+        }
+
+        private var action: SwipeAction
+
+        private var imageView: UIImageView?
+        private var titleView: UILabel!
+        private var gestureRecognizer: UITapGestureRecognizer!
+        private var stackView = UIStackView()
+
+        init(action: SwipeAction)
+        {
+            self.action = action
+            self.state = .pending
+            super.init(frame: .zero)
+
+            let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTap))
+            self.addGestureRecognizer(gestureRecognizer)
+            self.gestureRecognizer = gestureRecognizer
+
+            self.backgroundColor = action.backgroundColor ?? .red
+
+            if let title = action.title {
+                let titleView = UILabel()
+                titleView.text = title
+                titleView.textColor = .white
+                titleView.lineBreakMode = .byClipping
+                self.stackView.addArrangedSubview(titleView)
+                self.titleView = titleView
+            }
+
+            if let image = action.image {
+                let imageView = UIImageView(image: image)
+                self.stackView.addArrangedSubview(imageView)
+                self.imageView = imageView
+            }
+
+            stackView.spacing = 2
+            stackView.alignment = .center
+            stackView.axis = .vertical
+            stackView.distribution = .fill
+            stackView.isLayoutMarginsRelativeArrangement = true
+            stackView.layoutMargins = SwipeView.padding
+
+            self.addSubview(self.stackView)
+        }
+
+        required init?(coder: NSCoder)
+        {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layoutSubviews()
+        {
+            super.layoutSubviews()
+            self.stackView.frame = self.bounds
+        }
+
+        func preferredSize() -> CGSize
+        {
+            var size = self.titleView.sizeThatFits(self.bounds.size)
+            size.width += SwipeView.padding.left + SwipeView.padding.right
+            return size
+        }
+
+        @objc func onTap()
+        {
+            let _ = self.action.onTap(action)
+        }
+    }
+
+}

--- a/Listable/Sources/Item.swift
+++ b/Listable/Sources/Item.swift
@@ -103,6 +103,9 @@ public struct Item<Element:ItemElement> : AnyItem
         onDeselect : OnDeselect? = nil
         )
     {
+        assert((swipeActions != nil) == (swipeActionsAppearance != nil),
+               "A swipeActionsAppearance must be provided if swipeActions is provided")
+
         self.element = element
         self.appearance = appearance
         

--- a/Listable/Sources/Item.swift
+++ b/Listable/Sources/Item.swift
@@ -49,6 +49,7 @@ public struct Item<Element:ItemElement> : AnyItem
     public var selection : ItemSelection
     
     public var swipeActions : SwipeActions?
+    public var swipeActionsAppearance : Element.SwipeActionsAppearance?
     
     public var reordering : Reordering?
         
@@ -93,6 +94,7 @@ public struct Item<Element:ItemElement> : AnyItem
         layout : ItemLayout = ItemLayout(),
         selection : ItemSelection = .notSelectable,
         swipeActions : SwipeActions? = nil,
+        swipeActionsAppearance : Element.SwipeActionsAppearance? = nil,
         reordering : Reordering? = nil,
         bind : CreateBinding? = nil,
         onDisplay : OnDisplay? = nil,
@@ -110,6 +112,7 @@ public struct Item<Element:ItemElement> : AnyItem
         self.selection = selection
         
         self.swipeActions = swipeActions
+        self.swipeActionsAppearance = swipeActionsAppearance
         
         self.reordering = reordering
         

--- a/Listable/Sources/ItemElement.swift
+++ b/Listable/Sources/ItemElement.swift
@@ -180,11 +180,27 @@ public protocol ItemElementSwipeActionsAppearance
     
     /**
 
-     Called to apply the appearance to a given set of views before they are displayed on screen, or when an item position changes.
+     Called to apply the actions appearance to a given set of views before they are displayed on screen, or when an item position changes.
 
-     Eg, this is where you would set fonts, spacing, colors, etc, to apply your app's theme.
+     Eg, this is where you would set fonts, spacing, colors, etc, actions, to apply your app's theme.
      */
     func apply(swipeActions : SwipeActions, to view : ContentView)
+
+    /**
+
+    Called to apply the current SwipeControllerState to the underlying view.
+
+    Eg, the default iOS action view changes the title label alignment at different states in the swipe animation.
+    */
+    func apply(swipeControllerState: SwipeControllerState, to view : ContentView)
+
+    /**
+
+    Called to apply the actions appearance to a given set of views before they are displayed on screen, or when an item position changes.
+
+    Eg, this is where you would set fonts, spacing, colors, etc, actions, to apply your app's theme.
+    */
+    func preferredSize(for view: ContentView) -> CGSize
 }
 
 
@@ -202,6 +218,14 @@ public struct EmptyItemElementSwipeActionsAppearance : ItemElementSwipeActionsAp
     
     public func apply(swipeActions: SwipeActions, to view: UIView) {
         // Nothing.
+    }
+
+    public func apply(swipeControllerState: SwipeControllerState, to view: UIView) {
+        // no op
+    }
+
+    public func preferredSize(for view: UIView) -> CGSize {
+        return .zero
     }
 }
 

--- a/Listable/Sources/ItemElement.swift
+++ b/Listable/Sources/ItemElement.swift
@@ -152,7 +152,7 @@ public extension ItemElementAppearance where Self:Equatable
 
 
 /**
- TODO
+ Currently unsupported. Custom implementation for the swipe action views. 
  */
 public protocol ItemElementSwipeActionsAppearance
 {
@@ -160,12 +160,18 @@ public protocol ItemElementSwipeActionsAppearance
     // MARK: Creating & Providing Views
     //
     
-    /// TODO
+    /// The type of the content view of the swipe action view behind the element.
+    /// The content view is drawn under the elements ContentView
     associatedtype ContentView:UIView
     
     /**
-     TODO
-     */
+    Create and return a new set of views to be used to render the element.
+
+    These views are reused by the list view, similar to collection view or table view cell recycling.
+
+    Do not do configuration in this method that will be changed by your app's theme or appearance – instead
+    do that work in apply(to:), so the appearance will be updated if the appearance of elements changes.
+    */
     static func createView(frame : CGRect) -> ContentView
     
     //
@@ -173,7 +179,10 @@ public protocol ItemElementSwipeActionsAppearance
     //
     
     /**
-     TODO
+
+     Called to apply the appearance to a given set of views before they are displayed on screen, or when an item position changes.
+
+     Eg, this is where you would set fonts, spacing, colors, etc, to apply your app's theme.
      */
     func apply(swipeActions : SwipeActions, to view : ContentView)
 }

--- a/Listable/Sources/ItemElement.swift
+++ b/Listable/Sources/ItemElement.swift
@@ -38,6 +38,11 @@ public protocol ItemElement
      */
     associatedtype Appearance:ItemElementAppearance
     
+    /**
+     
+     */
+    associatedtype SwipeActionsAppearance:ItemElementSwipeActionsAppearance = EmptyItemElementSwipeActionsAppearance
+    
     //
     // MARK: Applying To Displayed View
     //
@@ -142,6 +147,52 @@ public extension ItemElementAppearance where Self:Equatable
     func isEquivalent(to other : Self) -> Bool
     {
         return self == other
+    }
+}
+
+
+/**
+ TODO
+ */
+public protocol ItemElementSwipeActionsAppearance
+{
+    //
+    // MARK: Creating & Providing Views
+    //
+    
+    /// TODO
+    associatedtype ContentView:UIView
+    
+    /**
+     TODO
+     */
+    static func createView(frame : CGRect) -> ContentView
+    
+    //
+    // MARK: Updating View State
+    //
+    
+    /**
+     TODO
+     */
+    func apply(swipeActions : SwipeActions, to view : ContentView)
+}
+
+
+public struct EmptyItemElementSwipeActionsAppearance : ItemElementSwipeActionsAppearance
+{
+    public init() {}
+    
+    // MARK: ItemElementSwipeActionsAppearance
+    
+    public typealias ContentView = UIView
+    
+    public static func createView(frame: CGRect) -> UIView {
+        return UIView(frame: frame)
+    }
+    
+    public func apply(swipeActions: SwipeActions, to view: UIView) {
+        // Nothing.
     }
 }
 

--- a/Listable/Sources/SwipeActions.swift
+++ b/Listable/Sources/SwipeActions.swift
@@ -37,7 +37,7 @@ public struct SwipeAction
     public typealias OnTap = (SwipeAction) -> Bool
     public var onTap : OnTap
     
-    public init(title: String?, backgroundColor: UIColor, image: UIImage? = nil, onTap : @escaping OnTap)
+    public init(title: String, backgroundColor: UIColor, image: UIImage? = nil, onTap : @escaping OnTap)
     {
         self.title = title
         self.backgroundColor = backgroundColor

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,7 +28,7 @@ DEPENDENCIES:
   - Snapshot/Tests (from `Internal Pods/Snapshot/Snapshot.podspec`)
 
 SPEC REPOS:
-  trunk:
+  https://cdn.cocoapods.org/:
     - BlueprintUI
     - BlueprintUICommonControls
 


### PR DESCRIPTION
*Started on top of Kyles Skeleton commit

Adds support for simple swipe to actions 

why simple? 
- no custom views
- only one action

What's going on? 

Created a SwipeController. The SwipeController manages the gesture of the cell itself and the state of the swipe. It helps calculate new states and fire the correct action. When actions are sent into a cell instance, a SwipeController and swipe view are created. 

*SwipeView* - a simple view that mimics the action view from UITableViewCell. 

The movement is handled with a UIPanGestureRecognizer added to the cell itself. 

-- video

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/2245012/78576527-a6529b80-77e1-11ea-8373-9b7387ccedf8.gif)

