### PR TITLE
Fix overscroll position calculation

### DIFF
--- a/Listable/Sources/Internal/Layout/ListViewLayout.LayoutInfo.swift
+++ b/Listable/Sources/Internal/Layout/ListViewLayout.LayoutInfo.swift
@@ -378,7 +378,7 @@ internal extension ListViewLayout
             let direction = self.appearance.direction
             
             let contentHeight = direction.height(for: self.contentSize)
-            let viewHeight = direction.height(for: collectionView.bounds.size)
+            let viewHeight = direction.height(for: collectionView.contentFrame.size)
             
             // Overscroll positioning is done after we've sized the layout, because the overscroll footer does not actually
             // affect any form of layout or sizing. It appears only once the scroll view has been scrolled outside of its normal bounds.

--- a/Listable/Sources/ListView/ListView.swift
+++ b/Listable/Sources/ListView/ListView.swift
@@ -814,25 +814,8 @@ extension ListView : KeyboardObserverDelegate
     }
 }
 
-
-
 fileprivate extension UIScrollView
 {
-
-    /// The frame of the collection view inset by the adjusted content inset,
-    /// i.e., the visible frame of the content.
-    var contentFrame : CGRect {
-        return self.bounds.inset(by: self.lst_adjustedContentInset)
-    }
-
-    /// `adjustedContentInset` on iOS >= 11, `contentInset` otherwise.
-    var lst_adjustedContentInset : UIEdgeInsets {
-        if #available(iOS 11, *) {
-            return self.adjustedContentInset
-        } else {
-            return self.contentInset
-        }
-    }
 
     func isScrolledNearBottom() -> Bool
     {

--- a/Listable/Sources/UIScrollView+Extensions.swift
+++ b/Listable/Sources/UIScrollView+Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  UIScrollView+Extensions.swift
+//  Listable
+//
+//  Created by Kyle Bashour on 4/10/20.
+//
+
+import UIKit
+
+extension UIScrollView {
+
+    /// The frame of the collection view inset by the adjusted content inset,
+    /// i.e., the visible frame of the content.
+    var contentFrame: CGRect {
+        return self.bounds.inset(by: self.lst_adjustedContentInset)
+    }
+
+    /// `adjustedContentInset` on iOS >= 11, `contentInset` otherwise.
+    var lst_adjustedContentInset: UIEdgeInsets {
+        if #available(iOS 11, *) {
+            return self.adjustedContentInset
+        } else {
+            return self.contentInset
+        }
+    }
+}


### PR DESCRIPTION
Fixes an issue where the wrong position was being calculated for the over scroll footer if the content height was less than the list view's frame, but larger than the frame minus the safe area. This resulted in the incorrect equation being used to calculate the position (since `if contentHeight >= viewHeight` was failing). This updates `viewHeight` to be based on the "content frame" as I like to call it, which is the frame of the view minus the adjusted content inset. 

| Before | After |
|-|-|
| ![Simulator Screen Shot - iPhone 11 - 2020-04-10 at 17 01 20](https://user-images.githubusercontent.com/3526783/79030354-768ef500-7b4d-11ea-9681-3fac687bff0f.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-10 at 16 59 51](https://user-images.githubusercontent.com/3526783/79030362-7ee73000-7b4d-11ea-8a3b-516e064345fe.png) |