### PR TITLE
Fix cell sizing

### DIFF
--- a/Listable/Sources/Internal/ItemElementCell.swift
+++ b/Listable/Sources/Internal/ItemElementCell.swift
@@ -71,7 +71,7 @@ final class ItemElementCell<Element:ItemElement> : UICollectionViewCell
     
     override func sizeThatFits(_ size: CGSize) -> CGSize
     {
-        return self.content.sizeThatFits(size)
+        return self.content.contentView.sizeThatFits(size)
     }
     
     override func layoutSubviews()


### PR DESCRIPTION
sizeThatFits on ItemElementCell needs to call self.content.contentView now, since the view passed in by the developer is now nested one layer deeper.