### PR TITLE
Integrate with os_signpost API

### DIFF
--- a/BlueprintLists/Sources/List.swift
+++ b/BlueprintLists/Sources/List.swift
@@ -28,6 +28,7 @@ public struct List : BlueprintUI.Element
             autoScrollAction: .none,
             scrollInsets: .init(),
             accessibilityIdentifier: nil,
+            debuggingIdentifier: nil,
             build: build
         )
     }

--- a/Listable/Sources/Debugging & Logging/SignpostLogger.swift
+++ b/Listable/Sources/Debugging & Logging/SignpostLogger.swift
@@ -1,0 +1,120 @@
+//
+//  SignpostLogger.swift
+//  Listable
+//
+//  Created by Kyle Van Essen on 5/8/20.
+//
+
+import os.signpost
+
+
+/// Log types available within Listable.
+extension OSLog {
+    static let updateContent = OSLog(
+        subsystem: "com.kve.Listable",
+        category: "ListView Update"
+    )
+    
+    static let scrollView = OSLog(
+        subsystem: "com.kve.Listable",
+        category: "ListView ScrollView"
+    )
+}
+
+
+/// An object which can be logged to `SignpostLogger`.
+protocol SignpostLoggable {
+    var signpostInfo : SignpostLoggingInfo { get }
+}
+
+
+/// The info logged to `SignpostLogger` from a `SignpostLoggable`.
+struct SignpostLoggingInfo {
+    var identifier : String?
+    var instanceIdentifier : String?
+}
+
+
+///
+/// Signpost logging is logging visible in Instruments.app
+///
+/// Listable utilizes signpost logging to instrument various parts of the
+/// list update cycle: Content diffing, Collection View updating, item and header/footer
+/// sizing, etc. 
+///
+/// Resources
+/// ---------
+///  WWDC: https://developer.apple.com/videos/play/wwdc2018/405/
+///  Swift By Sundell: https://www.swiftbysundell.com/wwdc2018/getting-started-with-signposts/
+///
+struct SignpostLogger {
+         
+    static func log<Output>(log : OSLog, name: StaticString, for loggable : SignpostLoggable? = nil, _ output : () -> Output) -> Output
+    {
+        self.log(.begin, log: log, name: name, for: loggable)
+        
+        let output = output()
+        
+        self.log(.end, log: log, name: name, for: loggable)
+        
+        return output
+    }
+    
+    static func log(_ type : EventType, log : OSLog, name: StaticString, for loggable : SignpostLoggable? = nil)
+    {
+        if #available(iOS 12.0, *) {
+            if let loggable = loggable {
+                os_signpost(
+                    type.toSignpostType,
+                    log: log,
+                    name: name,
+                    "%{public}s",
+                    Self.debuggingIdentifier(for: loggable)
+                )
+            } else {
+                os_signpost(
+                    type.toSignpostType,
+                    log: log,
+                    name: name
+                )
+            }
+        }
+    }
+    
+    enum EventType {
+        case begin
+        case event
+        case end
+        
+        @available(iOS 12.0, *)
+        var toSignpostType : OSSignpostType {
+            switch self {
+            case .begin: return .begin
+            case .event: return .event
+            case .end: return .end
+            }
+        }
+    }
+    
+    private static func debuggingIdentifier(for loggable : SignpostLoggable) -> String {
+        
+        let info = loggable.signpostInfo
+        
+        var components = [String]()
+        
+        components.append(
+            String(describing: type(of: loggable))
+        )
+        
+        if let id = info.identifier {
+            components.append(id)
+        }
+        
+        if let instanceID = info.instanceIdentifier {
+            components.append("(\(instanceID))")
+        }
+        
+        return components.joined(separator: " ")
+    }
+}
+

--- a/Listable/Sources/HeaderFooter.swift
+++ b/Listable/Sources/HeaderFooter.swift
@@ -30,6 +30,8 @@ public struct HeaderFooter<Element:HeaderFooterElement> : AnyHeaderFooter
     public var sizing : Sizing
     public var layout : HeaderFooterLayout
     
+    public var debuggingIdentifier : String? = nil
+    
     internal let reuseIdentifier : ReuseIdentifier<Element>
     
     //
@@ -86,6 +88,17 @@ public struct HeaderFooter<Element:HeaderFooterElement> : AnyHeaderFooter
     public func newPresentationHeaderFooterState() -> Any
     {
         return PresentationState.HeaderFooterState(self)
+    }
+}
+
+
+extension HeaderFooter : SignpostLoggable
+{
+    var signpostInfo : SignpostLoggingInfo {
+        SignpostLoggingInfo(
+            identifier: self.debuggingIdentifier,
+            instanceIdentifier: nil
+        )
     }
 }
 

--- a/Listable/Sources/Internal/PresentationState.swift
+++ b/Listable/Sources/Internal/PresentationState.swift
@@ -244,6 +244,12 @@ final class PresentationState
     
     func update(with diff : SectionedDiff<Section, AnyItem>, slice : Content.Slice)
     {
+        SignpostLogger.log(.begin, log: .updateContent, name: "Update Presentation State", for: self.view)
+        
+        defer {
+            SignpostLogger.log(.end, log: .updateContent, name: "Update Presentation State", for: self.view)
+        }
+        
         self.containsAllItems = slice.containsAllItems
         
         self.contentIdentifier = slice.content.identifier
@@ -499,6 +505,8 @@ final class PresentationState
             if let size = self.cachedSizes[key] {
                 return size
             } else {
+                SignpostLogger.log(.begin, log: .updateContent, name: "Measure HeaderFooter", for: self.model)
+                
                 let size : CGSize = measurementCache.use(
                     with: self.model.reuseIdentifier,
                     create: {
@@ -511,6 +519,8 @@ final class PresentationState
                 })
                 
                 self.cachedSizes[key] = size
+                
+                SignpostLogger.log(.end, log: .updateContent, name: "Measure HeaderFooter", for: self.model)
                 
                 return size
             }
@@ -731,6 +741,8 @@ final class PresentationState
             if let size = self.cachedSizes[key] {
                 return size
             } else {
+                SignpostLogger.log(.begin, log: .updateContent, name: "Measure ItemElement", for: self.model)
+                
                 let size : CGSize = measurementCache.use(
                     with: self.model.reuseIdentifier,
                     create: {
@@ -744,6 +756,8 @@ final class PresentationState
                 })
                 
                 self.cachedSizes[key] = size
+                
+                SignpostLogger.log(.end, log: .updateContent, name: "Measure ItemElement", for: self.model)
                 
                 return size
             }

--- a/Listable/Sources/Item.swift
+++ b/Listable/Sources/Item.swift
@@ -70,6 +70,8 @@ public struct Item<Element:ItemElement> : AnyItem
     public typealias CreateBinding = (Element) -> Binding<Element>
     internal let bind : CreateBinding?
     
+    public var debuggingIdentifier : String? = nil
+    
     //
     // MARK: Initialization
     //
@@ -171,6 +173,17 @@ public struct Item<Element:ItemElement> : AnyItem
     public func newPresentationItemState(in listView : ListView) -> Any
     {
         return PresentationState.ItemState(with: self, listView: listView)
+    }
+}
+
+
+extension Item : SignpostLoggable
+{
+    var signpostInfo : SignpostLoggingInfo {
+        SignpostLoggingInfo(
+            identifier: self.debuggingIdentifier,
+            instanceIdentifier: nil
+        )
     }
 }
 

--- a/Listable/Sources/ListDescription.swift
+++ b/Listable/Sources/ListDescription.swift
@@ -21,6 +21,8 @@ public struct ListDescription
     
     public var accessibilityIdentifier: String?
     
+    public var debuggingIdentifier: String?
+    
     public var content : Content
 
     public typealias Build = (inout ListDescription) -> ()
@@ -33,6 +35,7 @@ public struct ListDescription
         autoScrollAction : AutoScrollAction,
         scrollInsets : ScrollInsets,
         accessibilityIdentifier: String?,
+        debuggingIdentifier: String?,
         build : Build
     )
     {
@@ -44,6 +47,7 @@ public struct ListDescription
         self.autoScrollAction = autoScrollAction
         self.scrollInsets = scrollInsets
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.debuggingIdentifier = debuggingIdentifier
         
         self.content = Content()
 

--- a/Listable/Sources/ListItemElement.swift
+++ b/Listable/Sources/ListItemElement.swift
@@ -58,6 +58,7 @@ public struct ListItemElement : ItemElement, ItemElementAppearance
             autoScrollAction: .none,
             scrollInsets: .init(),
             accessibilityIdentifier: nil,
+            debuggingIdentifier: nil,
             build: build
         )
     }

--- a/Listable/Sources/ListView/ListView.Delegate.swift
+++ b/Listable/Sources/ListView/ListView.Delegate.swift
@@ -376,6 +376,12 @@ extension ListView
         {
             guard scrollView.bounds.size.height > 0 else { return }
             
+            SignpostLogger.log(.begin, log: .scrollView, name: "scrollViewDidScroll", for: self.view)
+            
+            defer {
+                SignpostLogger.log(.end, log: .scrollView, name: "scrollViewDidScroll", for: self.view)
+            }
+            
             // Updating Paged Content
             
             let scrollingDown = self.lastPosition < scrollView.contentOffset.y

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ struct DemoItem : BlueprintItemElement, Equatable
 }
 ```
 
+## Instruments.app Integration
+
+Listable provides integration with the `os_signpost` API for measuring the duration of events in your application. If you are experiencing issues with list performance in your app, you can profile it in Instruments, and add the `os_signpost` instrument to inspect the timing for various layout and update passes.
 
 ## Primary API & Surface Area
 


### PR DESCRIPTION
This allows integration with the `os_signpost` API in Instruments. This is a first pass at this, I can probably do more advanced things with the API, but seems like a reasonable starting point.

<img width="1500" alt="Screen Shot 2020-05-08 at 1 31 47 PM" src="https://user-images.githubusercontent.com/327847/81446791-50e71280-9130-11ea-8f7c-b195f567235f.png">
