### PR TITLE
Remove value check when setting SwipeActionState, it breaks gesture handling

### DIFF
--- a/Listable/Sources/Internal/ItemElementCell.ContentViewContainer.swift
+++ b/Listable/Sources/Internal/ItemElementCell.ContentViewContainer.swift
@@ -203,10 +203,6 @@ extension ItemElementCell {
 
         private func set(state: SwipeActionState, animated: Bool = false) {
             
-            guard swipeState != state else {
-                return
-            }
-            
             swipeState = state
 
             if animated {


### PR DESCRIPTION
I broke this in my merged PR. Not checking this equality ensures that the gesture continues to be handled, so, remove this check for now.