### PR TITLE
Support tappable headers

### DIFF
--- a/BlueprintLists/Sources/HeaderFooter.swift
+++ b/BlueprintLists/Sources/HeaderFooter.swift
@@ -13,28 +13,82 @@ public typealias BlueprintHeaderContent = BlueprintHeaderFooterContent
 public typealias BlueprintFooterContent = BlueprintHeaderFooterContent
 
 
-public protocol BlueprintHeaderFooterContent : HeaderFooterContent where ContentView == BlueprintView
+public protocol BlueprintHeaderFooterContent : HeaderFooterContent
+where
+    ContentView == BlueprintView,
+    BackgroundView == BlueprintView,
+    PressedBackgroundView == BlueprintView
 {
     //
     // MARK: Creating Blueprint Element Representations
     //
     
+    /// Required. Create and return the Blueprint element used to represent the content.
     var elementRepresentation : Element { get }
+    
+    /// Optional. Create and return the Blueprint element used to represent the background of the content.
+    /// You usually provide this method alongside `pressedBackground`, if your content
+    /// supports an `onTap` handler.
+    ///
+    /// Note
+    /// ----
+    /// The default implementation of this method returns nil, and provides no background.
+    ///
+    var background : Element? { get }
+    
+    /// Optional. Create and return the Blueprint element used to represent the background of the content when it is pressed.
+    /// You usually provide this method alongside `background`, if your content supports an `onTap` handler.
+    ///
+    /// Note
+    /// ----
+    /// The default implementation of this method returns nil, and provides no selected background.
+    ///
+    var pressedBackground : Element? { get }
 }
 
 
 public extension BlueprintHeaderFooterContent
 {
     //
+    // MARK: BlueprintHeaderFooterContent
+    //
+    
+    var background : Element? {
+        nil
+    }
+    
+    var pressedBackground : Element? {
+        nil
+    }
+    
+    //
     // MARK: HeaderFooterContent
     //
     
-    func apply(to view: ContentView, reason: ApplyReason)
+    func apply(to views: HeaderFooterContentViews<Self>, reason: ApplyReason)
     {
-        view.element = self.elementRepresentation
+        views.content.element = self.elementRepresentation
+        views.background.element = self.background
+        views.pressed.element = self.pressedBackground
     }
     
-    static func createReusableHeaderFooterView(frame: CGRect) -> ContentView
+    static func createReusableContentView(frame: CGRect) -> ContentView
+    {
+        let view = BlueprintView(frame: frame)
+        view.backgroundColor = .clear
+        
+        return view
+    }
+    
+    static func createReusableBackgroundView(frame: CGRect) -> BackgroundView
+    {
+        let view = BlueprintView(frame: frame)
+        view.backgroundColor = .clear
+        
+        return view
+    }
+    
+    static func createReusablePressedBackgroundView(frame: CGRect) -> PressedBackgroundView
     {
         let view = BlueprintView(frame: frame)
         view.backgroundColor = .clear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Simplify `Sizing` now that enums support default associated values.](https://github.com/kyleve/Listable/pull/189). Now instead of separate `.thatFits` and `.thatFitsWith(Constraint)` enums, there is a single `.thatFits(Constraint = .noConstraint)` case (the same applies for `autolayout`).
 
-- Changed [how `zIndexes` are assigned to header and items, and support tapping headers / footers](https://github.com/kyleve/Listable/pull/193). This allows registering an `onTap` handler for any HeaderFooter, and providing a backgrouned to display while the tap's press is active.
+- Changed [how `zIndexes` are assigned to header and items, and support tapping headers / footers](https://github.com/kyleve/Listable/pull/193). This allows registering an `onTap` handler for any HeaderFooter, and providing a background to display while the tap's press is active.
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - [Simplify `Sizing` now that enums support default associated values.](https://github.com/kyleve/Listable/pull/189). Now instead of separate `.thatFits` and `.thatFitsWith(Constraint)` enums, there is a single `.thatFits(Constraint = .noConstraint)` case (the same applies for `autolayout`).
 
+- Changed [how `zIndexes` are assigned to header and items, and support tapping headers / footers](https://github.com/kyleve/Listable/pull/193). This allows registering an `onTap` handler for any HeaderFooter, and providing a backgrouned to display while the tap's press is active.
+
 ### Misc
 
 # Past Releases

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A07119324BA798400CDF65D /* ListStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A07119224BA798400CDF65D /* ListStateViewController.swift */; };
 		0A0E070423870A5700DDD27D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0A0E070323870A5700DDD27D /* README.md */; };
+		0A47C33A24E237A900EE4315 /* AccordionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A47C33924E237A900EE4315 /* AccordionViewController.swift */; };
 		0A87BA652463567B0047C3B5 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 0A87BA642463567B0047C3B5 /* CHANGELOG.md */; };
 		0AA4D9B9248064A300CF95A5 /* CustomLayoutsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9A8248064A200CF95A5 /* CustomLayoutsViewController.swift */; };
 		0AA4D9BA248064A300CF95A5 /* FlowLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9A9248064A200CF95A5 /* FlowLayoutViewController.swift */; };
@@ -44,6 +45,7 @@
 		06908B38E59ACD7502B5332F /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		0A07119224BA798400CDF65D /* ListStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListStateViewController.swift; sourceTree = "<group>"; };
 		0A0E070323870A5700DDD27D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		0A47C33924E237A900EE4315 /* AccordionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccordionViewController.swift; sourceTree = "<group>"; };
 		0A87BA642463567B0047C3B5 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		0AA4D9A8248064A200CF95A5 /* CustomLayoutsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomLayoutsViewController.swift; sourceTree = "<group>"; };
 		0AA4D9A9248064A200CF95A5 /* FlowLayoutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlowLayoutViewController.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 		0AA4D9CA248064AE00CF95A5 /* Demo Screens */ = {
 			isa = PBXGroup;
 			children = (
+				0A47C33924E237A900EE4315 /* AccordionViewController.swift */,
 				0AA4D9B4248064A300CF95A5 /* AutoScrollingViewController.swift */,
 				0AA4D9AC248064A300CF95A5 /* BlueprintListDemoViewController.swift */,
 				0AA4D9B2248064A300CF95A5 /* CollectionViewAppearance.swift */,
@@ -425,6 +428,7 @@
 				0AA4D9C9248064A300CF95A5 /* CollectionViewBasicDemoViewController.swift in Sources */,
 				0AA4D9BC248064A300CF95A5 /* KeyboardTestingViewController.swift in Sources */,
 				0AA4D9C1248064A300CF95A5 /* CoordinatorViewController.swift in Sources */,
+				0A47C33A24E237A900EE4315 /* AccordionViewController.swift in Sources */,
 				0AA4D9B9248064A300CF95A5 /* CustomLayoutsViewController.swift in Sources */,
 				0AA4D9C3248064A300CF95A5 /* CollectionViewAppearance.swift in Sources */,
 				2B8804652490844A003BB351 /* SpacingCustomizationViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/AccordionViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/AccordionViewController.swift
@@ -1,0 +1,106 @@
+//
+//  AccordionViewController.swift
+//  Demo
+//
+//  Created by Kyle Van Essen on 8/10/20.
+//  Copyright © 2020 Kyle Van Essen. All rights reserved.
+//
+
+
+import BlueprintLists
+import BlueprintUICommonControls
+
+
+final class AccordionViewController : ListViewController
+{
+    var expandedSectionIndex : Int = 1
+    
+    override func configure(list: inout ListProperties) {
+        
+        list += (1...10).map { sectionIndex in
+            
+            Section(sectionIndex) { section in
+                
+                section.header = HeaderFooter(
+                    AccordionHeader(text: "Section Header #\(sectionIndex)"),
+                    onTap: { _ in
+                        self.expandedSectionIndex = sectionIndex
+                        self.reload(animated: true)
+                    }
+                )
+                
+                if expandedSectionIndex == sectionIndex {
+                    section += (1...sectionIndex).map { itemIndex in
+                        Item(AccordionRow(text: "Row #\(sectionIndex), \(itemIndex)")) {
+                            $0.insertAndRemoveAnimations = .fade
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fileprivate struct AccordionHeader : BlueprintHeaderFooterContent, Equatable
+{
+    var text : String
+    
+    var elementRepresentation: Element {
+        Label(text: self.text) {
+            $0.alignment = .left
+            $0.font = .systemFont(ofSize: 18.0, weight: .semibold)
+        }
+        .inset(horizontal: 20.0, vertical: 10.0)
+        .constrainedTo(height: .atLeast(80.0))
+    }
+    
+    var background: Element? {
+        self.background(with: .white)
+    }
+    
+    var pressedBackground: Element? {
+        self.background(with: .white(0.9))
+    }
+    
+    private func background(with color : UIColor) -> Element {
+        Overlay(
+            elements: [
+                Box(backgroundColor: color),
+                
+                Box(backgroundColor: .init(white: 0.85, alpha: 1.0))
+                    .constrainedTo(height: .absolute(1.0))
+                    .aligned(vertically: .bottom, horizontally: .fill)
+            ]
+        )
+    }
+}
+
+
+fileprivate struct AccordionRow : BlueprintItemContent, Equatable
+{
+    var text : String
+    
+    var identifier: Identifier<AccordionRow> {
+        .init(text)
+    }
+    
+    func element(with info: ApplyItemContentInfo) -> Element {
+        Label(text: self.text) {
+            $0.alignment = .left
+            $0.font = .systemFont(ofSize: 16.0, weight: .regular)
+        }
+        .inset(horizontal: 20.0, vertical: 10.0)
+        .constrainedTo(height: .atLeast(60.0))
+    }
+    
+    func backgroundElement(with info: ApplyItemContentInfo) -> Element? {
+        Overlay(
+            elements: [
+                Box(backgroundColor: .white),
+                Box(backgroundColor: .init(white: 0.90, alpha: 1.0))
+                    .constrainedTo(height: .absolute(1.0))
+                    .aligned(vertically: .bottom, horizontally: .fill)
+            ]
+        )
+    }
+}

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -123,6 +123,13 @@ public final class DemosRootViewController : ListViewController
                 onSelect: { _ in
                     self.push(ItemInsertAndRemoveAnimationsViewController())
             })
+            
+            section += Item(
+                DemoItem(text: "Accordion View"),
+                selectionStyle: .tappable,
+                onSelect: { _ in
+                    self.push(AccordionViewController())
+            })
         }
         
         list("layouts") { section in

--- a/Listable/Sources/HeaderFooter/HeaderFooter.swift
+++ b/Listable/Sources/HeaderFooter/HeaderFooter.swift
@@ -34,6 +34,9 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     public var sizing : Sizing
     public var layout : HeaderFooterLayout
     
+    public typealias OnTap = (Content) -> ()
+    public var onTap : OnTap?
+    
     public var debuggingIdentifier : String? = nil
     
     internal let reuseIdentifier : ReuseIdentifier<Content>
@@ -47,8 +50,7 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     public init(
         _ content : Content,
         build : Build
-        )
-    {
+    ) {
         self.init(content)
         
         build(&self)
@@ -57,12 +59,15 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     public init(
         _ content : Content,
         sizing : Sizing = .thatFits(.init(.atLeast(.default))),
-        layout : HeaderFooterLayout = HeaderFooterLayout()
+        layout : HeaderFooterLayout = HeaderFooterLayout(),
+        onTap : OnTap? = nil
     ) {
         self.content = content
         
         self.sizing = sizing
         self.layout = layout
+        
+        self.onTap = onTap
         
         self.reuseIdentifier = ReuseIdentifier.identifier(for: Content.self)
     }
@@ -71,9 +76,15 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     
     public func apply(to anyView : UIView, reason: ApplyReason)
     {
-        let view = anyView as! Content.ContentView
+        let view = anyView as! HeaderFooterContentView<Content>
         
-        self.content.apply(to: view, reason: reason)
+        let views = HeaderFooterContentViews<Content>(
+            content: view.content,
+            background: view.background,
+            pressed: view.pressedBackground
+        )
+        
+        self.content.apply(to: views, reason: reason)
     }
         
     public func anyIsEquivalent(to other : AnyHeaderFooter) -> Bool
@@ -106,9 +117,10 @@ extension HeaderFooter : SignpostLoggable
 public struct HeaderFooterLayout : Equatable
 {
     public var width : CustomWidth
-    
-    public init(width : CustomWidth = .default)
-    {
+        
+    public init(
+        width : CustomWidth = .default
+    ) {
         self.width = width
     }
 }

--- a/Listable/Sources/HeaderFooter/HeaderFooterContent.swift
+++ b/Listable/Sources/HeaderFooter/HeaderFooterContent.swift
@@ -16,7 +16,7 @@ public protocol HeaderFooterContent
     // MARK: Applying To Displayed View
     //
     
-    func apply(to view : ContentView, reason : ApplyReason)
+    func apply(to views : HeaderFooterContentViews<Self>, reason : ApplyReason)
     
     //
     // MARK: Tracking Changes
@@ -25,12 +25,82 @@ public protocol HeaderFooterContent
     func isEquivalent(to other : Self) -> Bool
     
     //
-    // MARK: Creating & Providing Views
+    // MARK: Creating & Providing Content Views
     //
     
+    /// The content view used to draw the content.
+    /// The content view is drawn at the top of the view hierarchy, above the background views.
     associatedtype ContentView:UIView
     
-    static func createReusableHeaderFooterView(frame : CGRect) -> ContentView
+
+    /// Create and return a new content view used to render the content.
+    ///
+    /// Note
+    /// ----
+    /// Do not do configuration in this method that will be changed by your view's theme or appearance – instead
+    /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
+    static func createReusableContentView(frame : CGRect) -> ContentView
+    
+    //
+    // MARK: Creating & Providing Background Views
+    //
+    
+    /// The background view used to draw the background of the content.
+    /// The background view is drawn below the content view.
+    ///
+    /// Note
+    /// ----
+    /// Defaults to a `UIView` with no drawn appearance or state.
+    /// You do not need to provide this `typealias` unless you would like
+    /// to draw a background view.
+    ///
+    associatedtype BackgroundView:UIView = UIView
+    
+    /// Create and return a new background view used to render the content's background.
+    ///
+    /// Note
+    /// ----
+    /// Do not do configuration in this method that will be changed by your view's theme or appearance – instead
+    /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
+    static func createReusableBackgroundView(frame : CGRect) -> BackgroundView
+    
+    /// The selected background view used to draw the background of the content when it is selected or highlighted.
+    /// The selected background view is drawn below the content view.
+    ///
+    /// Note
+    /// ----
+    /// Defaults to a `UIView` with no drawn appearance or state.
+    /// You do not need to provide this `typealias` unless you would like
+    /// to draw a selected background view.
+    ///
+    associatedtype PressedBackgroundView:UIView = BackgroundView
+    
+    /// Create and return a new background view used to render the content's pressed background.
+    ///
+    /// This view is displayed when the user taps/presses the header / footer.
+    ///
+    /// If your `BackgroundView` and `SelectedBackgroundView` are the same type, this method
+    /// is provided automatically by calling `createReusableBackgroundView`.
+    ///
+    /// Note
+    /// ----
+    /// Do not do configuration in this method that will be changed by your view's theme or appearance – instead
+    /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
+    static func createReusablePressedBackgroundView(frame : CGRect) -> PressedBackgroundView
+}
+
+
+/// The views owned by the item content, passed to the `apply(to:) method to theme and provide content.`
+public struct HeaderFooterContentViews<Content:HeaderFooterContent>
+{
+    /// The content view of the content.
+    public var content : Content.ContentView
+    
+    /// The background view of the content.
+    public var background : Content.BackgroundView
+    
+    /// The background view of the content that's displayed while a press is active.
+    public var pressed : Content.PressedBackgroundView
 }
 
 
@@ -43,5 +113,22 @@ public extension HeaderFooterContent where Self:Equatable
     func isEquivalent(to other : Self) -> Bool
     {
         return self == other
+    }
+}
+
+
+public extension HeaderFooterContent where Self.BackgroundView == UIView
+{
+    static func createReusableBackgroundView(frame : CGRect) -> BackgroundView
+    {
+        BackgroundView(frame: frame)
+    }
+}
+
+public extension HeaderFooterContent where Self.PressedBackgroundView == BackgroundView
+{
+    static func createReusablePressedBackgroundView(frame : CGRect) -> PressedBackgroundView
+    {
+        self.createReusableBackgroundView(frame: frame)
     }
 }

--- a/Listable/Sources/Internal/HeaderFooterContentView.swift
+++ b/Listable/Sources/Internal/HeaderFooterContentView.swift
@@ -100,7 +100,10 @@ final class HeaderFooterContentView<Content:HeaderFooterContent> : UIView
         
         switch state {
 
-        case .possible, .began, .changed:
+        case .possible:
+            break
+        
+        case .began, .changed:
             self.pressedBackground.alpha = 1.0
             
         case .ended, .cancelled, .failed:

--- a/Listable/Sources/Internal/HeaderFooterContentView.swift
+++ b/Listable/Sources/Internal/HeaderFooterContentView.swift
@@ -81,14 +81,14 @@ final class HeaderFooterContentView<Content:HeaderFooterContent> : UIView
         self.removeGestureRecognizer(self.pressRecognizer)
         
         if self.onTap != nil {
-            self.accessibilityTraits = [.button]
+            self.accessibilityTraits = [.header, .button]
             
             self.pressedBackground.isHidden = false
             self.pressedBackground.alpha = 0.0
             
             self.addGestureRecognizer(self.pressRecognizer)
         } else {
-            self.accessibilityTraits = []
+            self.accessibilityTraits = [.header]
             
             self.pressedBackground.isHidden = true
         }

--- a/Listable/Sources/Internal/HeaderFooterContentView.swift
+++ b/Listable/Sources/Internal/HeaderFooterContentView.swift
@@ -1,0 +1,166 @@
+//
+//  HeaderFooterContentView.swift
+//  Listable
+//
+//  Created by Kyle Van Essen on 8/11/20.
+//
+
+import UIKit
+
+
+final class HeaderFooterContentView<Content:HeaderFooterContent> : UIView
+{
+    //
+    // MARK: Properties
+    //
+    
+    typealias OnTap = () -> ()
+    
+    var onTap : OnTap? = nil {
+        didSet { self.updateIsTappable() }
+    }
+    
+    let content : Content.ContentView
+    let background : Content.BackgroundView
+    let pressedBackground : Content.PressedBackgroundView
+    
+    private let pressRecognizer : PressGestureRecognizer
+    
+    //
+    // MARK: Initialization
+    //
+    
+    override init(frame: CGRect) {
+        
+        let bounds = CGRect(origin: .zero, size: frame.size)
+        
+        self.content = Content.createReusableContentView(frame: bounds)
+        self.background = Content.createReusableBackgroundView(frame: bounds)
+        self.pressedBackground = Content.createReusablePressedBackgroundView(frame: bounds)
+        
+        self.pressRecognizer = PressGestureRecognizer()
+        self.pressRecognizer.minimumPressDuration = 0.0
+        self.pressRecognizer.allowableMovementAfterBegin = 5.0
+        
+        super.init(frame: frame)
+        
+        self.pressRecognizer.addTarget(self, action: #selector(pressStateChanged))
+     
+        self.addSubview(self.background)
+        self.addSubview(self.pressedBackground)
+        self.addSubview(self.content)
+        
+        self.updateIsTappable()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+    
+    //
+    // MARK: UIView
+    //
+    
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        self.content.sizeThatFits(size)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.content.frame = self.bounds
+        self.background.frame = self.bounds
+        self.pressedBackground.frame = self.bounds
+    }
+    
+    //
+    // MARK: Tap Handling
+    //
+    
+    private func updateIsTappable()
+    {
+        self.removeGestureRecognizer(self.pressRecognizer)
+        
+        if self.onTap != nil {
+            self.accessibilityTraits = [.button]
+            
+            self.pressedBackground.isHidden = false
+            self.pressedBackground.alpha = 0.0
+            
+            self.addGestureRecognizer(self.pressRecognizer)
+        } else {
+            self.accessibilityTraits = []
+            
+            self.pressedBackground.isHidden = true
+        }
+    }
+    
+    @objc private func pressStateChanged() {
+        
+        let state = self.pressRecognizer.state
+        
+        switch state {
+
+        case .possible, .began, .changed:
+            self.pressedBackground.alpha = 1.0
+            
+        case .ended, .cancelled, .failed:
+            let didEnd = state == .ended
+            
+            UIView.animate(withDuration: didEnd ? 0.1 : 0.0) {
+                self.pressedBackground.alpha = 0.0
+            }
+            
+            if didEnd {
+                self.onTap?()
+            }
+            
+        @unknown default: break
+        }
+    }
+}
+
+
+fileprivate final class PressGestureRecognizer : UILongPressGestureRecognizer {
+    
+    var allowableMovementAfterBegin : CGFloat = 0.0
+    
+    private var initialPoint : CGPoint? = nil
+    
+    override func reset() {
+        super.reset()
+        
+        self.initialPoint = nil
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesBegan(touches, with: event)
+        
+        self.initialPoint = self.location(in: self.view)
+    }
+    
+    override func canPrevent(_ gesture: UIGestureRecognizer) -> Bool {
+        
+        // We want to allow the pan gesture of our containing scroll view to continue to track
+        // when the user moves their finger vertically or horizontally, when we are cancelled.
+        
+        if let panGesture = gesture as? UIPanGestureRecognizer, panGesture.view is UIScrollView {
+            return false
+        }
+        
+        return super.canPrevent(gesture)
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesMoved(touches, with: event)
+        
+        if let initialPoint = self.initialPoint {
+            let currentPoint = self.location(in: self.view)
+            
+            let distance = sqrt(pow(abs(initialPoint.x - currentPoint.x), 2) + pow(abs(initialPoint.y - currentPoint.y), 2))
+            
+            if distance > self.allowableMovementAfterBegin {
+                self.state = .failed
+            }
+        }
+    }
+}

--- a/Listable/Sources/Item/Item.swift
+++ b/Listable/Sources/Item/Item.swift
@@ -306,15 +306,15 @@ public struct ItemLayout : Equatable
     public var itemToSectionFooterSpacing : CGFloat?
     
     public var width : CustomWidth
-    
+        
     public init(
         itemSpacing : CGFloat? = nil,
         itemToSectionFooterSpacing : CGFloat? = nil,
         width : CustomWidth = .default
-    )
-    {
+    ) {
         self.itemSpacing = itemSpacing
         self.itemSpacing = itemSpacing
+        
         self.width = width
     }
 }

--- a/Listable/Sources/Layout/CollectionViewLayout.swift
+++ b/Listable/Sources/Layout/CollectionViewLayout.swift
@@ -289,7 +289,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             return true
         }())
         
-        self.layout.updateLayout(in: self.collectionView!)
+        self.performLayoutUpdate()
     }
     
     override func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem])
@@ -330,7 +330,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             direction: self.layout.direction,
             showsScrollIndicators: self.appearance.showsScrollIndicators
         )
-        
+                
         self.performLayout()
     }
     
@@ -347,10 +347,21 @@ final class CollectionViewLayout : UICollectionViewLayout
             
         self.layout.updateLayout(in: view)
         
+        self.layout.setZIndexes()
+        
         self.layout.updateOverscrollFooterPosition(in: view)
         self.layout.adjustPositionsForLayoutUnderflow(in: view)
-        
+                
         self.viewProperties = CollectionViewLayoutProperties(collectionView: view)
+    }
+    
+    private func performLayoutUpdate()
+    {
+        let view = self.collectionView!
+        
+        self.layout.positionStickySectionHeadersIfNeeded(in: view)
+        
+        self.layout.updateLayout(in: view)
     }
     
     //

--- a/Listable/Sources/Layout/Grid/GridListLayout.swift
+++ b/Listable/Sources/Layout/Grid/GridListLayout.swift
@@ -185,9 +185,7 @@ final class GridListLayout : ListLayout
     
     func updateLayout(in collectionView: UICollectionView)
     {
-        if self.layoutAppearance.stickySectionHeaders {
-            self.applyStickySectionHeaders(in: collectionView)
-        }
+        
     }
     
     func layout(

--- a/Listable/Sources/Layout/List/DefaultListLayout.swift
+++ b/Listable/Sources/Layout/List/DefaultListLayout.swift
@@ -316,9 +316,7 @@ final class DefaultListLayout : ListLayout
     
     func updateLayout(in collectionView : UICollectionView)
     {
-        if self.layoutAppearance.stickySectionHeaders {
-            self.applyStickySectionHeaders(in: collectionView)
-        }
+        
     }
     
     func layout(

--- a/Listable/Sources/Layout/ListLayout/ListLayoutAppearance.swift
+++ b/Listable/Sources/Layout/ListLayout/ListLayoutAppearance.swift
@@ -13,4 +13,6 @@ public protocol ListLayoutAppearance : Equatable
     static var `default` : Self { get }
     
     var direction : LayoutDirection { get }
+    
+    var stickySectionHeaders : Bool { get }
 }

--- a/Listable/Sources/Layout/ListLayout/ListLayoutContent.swift
+++ b/Listable/Sources/Layout/ListLayout/ListLayoutContent.swift
@@ -228,6 +228,8 @@ protocol ListLayoutContentItem : AnyObject
     var size : CGSize { get set }
     var x : CGFloat { get set }
     var y : CGFloat { get set }
+    
+    var zIndex : Int { get set }
 }
 
 
@@ -303,7 +305,11 @@ public extension ListLayoutContent
     {
         static func empty(_ kind : SupplementaryKind) -> SupplementaryItemInfo
         {
-            SupplementaryItemInfo(kind: kind, layout: .init(), isPopulated: false, measurer: { _ in .zero })
+            SupplementaryItemInfo(
+                kind: kind,
+                layout: .init(),
+                isPopulated: false, measurer: { _ in .zero }
+            )
         }
         
         let kind : SupplementaryKind
@@ -311,7 +317,7 @@ public extension ListLayoutContent
         let measurer : (Sizing.MeasureInfo) -> CGSize
                 
         let isPopulated : Bool
-                
+                        
         var size : CGSize = .zero
         
         var x : CGFloat = .zero
@@ -319,6 +325,8 @@ public extension ListLayoutContent
         
         var y : CGFloat = .zero
         var pinnedY : CGFloat? = nil
+        
+        var zIndex : Int = 0
         
         var defaultFrame : CGRect {
             CGRect(
@@ -344,6 +352,7 @@ public extension ListLayoutContent
             measurer : @escaping (Sizing.MeasureInfo) -> CGSize
         ) {
             self.kind = kind
+            
             self.layout = layout
             self.isPopulated = isPopulated
             self.measurer = measurer
@@ -354,7 +363,7 @@ public extension ListLayoutContent
             let attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: self.kind.rawValue, with: indexPath)
             
             attributes.frame = self.visibleFrame
-            attributes.zIndex = self.kind.zIndex
+            attributes.zIndex = self.zIndex
             
             return attributes
         }
@@ -371,10 +380,13 @@ public extension ListLayoutContent
         let measurer : (Sizing.MeasureInfo) -> CGSize
         
         var position : ItemPosition = .single
-        
+                
         var size : CGSize = .zero
+                
         var x : CGFloat = .zero
         var y : CGFloat = .zero
+        
+        var zIndex : Int = 0
         
         var frame : CGRect {
             CGRect(
@@ -392,7 +404,7 @@ public extension ListLayoutContent
         ) {
             self.delegateProvidedIndexPath = delegateProvidedIndexPath
             self.liveIndexPath = liveIndexPath
-            
+                        
             self.layout = layout
             self.insertAndRemoveAnimations = insertAndRemoveAnimations
             
@@ -404,7 +416,7 @@ public extension ListLayoutContent
             let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
             
             attributes.frame = self.frame
-            attributes.zIndex = 0
+            attributes.zIndex = self.zIndex
             
             return attributes
         }

--- a/Listable/Sources/Layout/Paged/PagedListLayout.swift
+++ b/Listable/Sources/Layout/Paged/PagedListLayout.swift
@@ -58,6 +58,8 @@ public struct PagedAppearance : ListLayoutAppearance
     /// The direction the paging layout should occur in. Defaults to `vertical`.
     public var direction: LayoutDirection
     
+    public let stickySectionHeaders: Bool = false
+    
     /// If scroll indicators should be visible along the scrollable axis.
     public var showsScrollIndicators : Bool
     

--- a/Listable/Sources/Layout/SupplementaryKind.swift
+++ b/Listable/Sources/Layout/SupplementaryKind.swift
@@ -17,18 +17,6 @@ enum SupplementaryKind : String, CaseIterable
     case sectionFooter = "Listable.SectionFooter"
     
     case overscrollFooter = "Listable.OverscrollFooter"
-        
-    var zIndex : Int {
-        switch self {
-        case .listHeader: return 1
-        case .listFooter: return 1
-            
-        case .sectionHeader: return 2
-        case .sectionFooter: return 1
-            
-        case .overscrollFooter: return 1
-        }
-    }
     
     func indexPath(in section : Int) -> IndexPath
     {

--- a/Listable/Sources/ListView/ListView.VisibleContent.swift
+++ b/Listable/Sources/ListView/ListView.VisibleContent.swift
@@ -10,12 +10,12 @@ import Foundation
 
 extension ListView
 {
-    struct VisibleContent
+    final class VisibleContent
     {
         private(set) var headerFooters : Set<HeaderFooter> = Set()
         private(set) var items : Set<Item> = Set()
         
-        mutating func update(with view : ListView)
+        func update(with view : ListView)
         {
             let (newItems, newHeaderFooters) = self.calculateVisibleContent(in: view)
             

--- a/Listable/Tests/Internal/SupplementaryItemViewTests.swift
+++ b/Listable/Tests/Internal/SupplementaryItemViewTests.swift
@@ -58,7 +58,7 @@ class SupplementaryContainerViewTests: XCTestCase
         
         let content = view.content!
         
-        XCTAssertTrue(type(of: content) === TestHeaderFooterContent.View.self)
+        XCTAssertTrue(type(of: content) === HeaderFooterContentView<TestHeaderFooterContent>.self)
         XCTAssertEqual(view.frame.size, CGSize(width: 100, height: 100))
         
         // Unset the header footer, make sure the view is pushed back into the cache.
@@ -94,11 +94,11 @@ fileprivate struct TestHeaderFooterContent : HeaderFooterContent, Equatable
 {
     // MARK: HeaderFooterContent
     
-    func apply(to view: View, reason: ApplyReason) {}
+    func apply(to views : HeaderFooterContentViews<Self>, reason: ApplyReason) {}
         
     typealias ContentView = View
     
-    static func createReusableHeaderFooterView(frame: CGRect) -> View
+    static func createReusableContentView(frame: CGRect) -> View
     {
         return View(frame: frame)
     }

--- a/Listable/Tests/Layout/List/DefaultListLayoutTests.swift
+++ b/Listable/Tests/Layout/List/DefaultListLayoutTests.swift
@@ -148,8 +148,8 @@ fileprivate struct TestingHeaderFooterContent : HeaderFooterContent {
     
     var color : UIColor
     
-    func apply(to view: UIView, reason: ApplyReason) {
-        view.backgroundColor = self.color
+    func apply(to views : HeaderFooterContentViews<Self>, reason: ApplyReason) {
+        views.content.backgroundColor = self.color
     }
     
     func isEquivalent(to other: TestingHeaderFooterContent) -> Bool {
@@ -158,7 +158,7 @@ fileprivate struct TestingHeaderFooterContent : HeaderFooterContent {
     
     typealias ContentView = UIView
     
-    static func createReusableHeaderFooterView(frame: CGRect) -> UIView {
+    static func createReusableContentView(frame: CGRect) -> UIView {
         UIView(frame: frame)
     }
 }

--- a/Listable/Tests/Layout/ListLayout/LayoutDescriptionTests.swift
+++ b/Listable/Tests/Layout/ListLayout/LayoutDescriptionTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Listable
 
 
-final class LayoutDescriptionTests : XCTest
+final class LayoutDescriptionTests : XCTestCase
 {
     func test_createPopulatedLayout()
     {

--- a/Listable/Tests/Layout/ListLayout/ListLayoutContentTests.swift
+++ b/Listable/Tests/Layout/ListLayout/ListLayoutContentTests.swift
@@ -256,3 +256,4 @@ fileprivate func AssertListLayoutContentItemEqual(
         XCTAssertTrue(lhs === rhs, "")
     }
 }
+

--- a/Listable/Tests/Layout/ListLayout/ListLayoutTests.swift
+++ b/Listable/Tests/Layout/ListLayout/ListLayoutTests.swift
@@ -1,0 +1,15 @@
+//
+//  ListLayoutTests.swift
+//  Listable-Unit-Tests
+//
+//  Created by Kyle Van Essen on 8/10/20.
+//
+
+import XCTest
+@testable import Listable
+
+
+final class ListLayoutTests : XCTestCase
+{
+    
+}

--- a/Listable/Tests/Layout/Paged/PagedListLayoutTests.swift
+++ b/Listable/Tests/Layout/Paged/PagedListLayoutTests.swift
@@ -105,8 +105,8 @@ fileprivate struct TestingHeaderFooterContent : HeaderFooterContent {
     
     var color : UIColor
     
-    func apply(to view: UIView, reason: ApplyReason) {
-        view.backgroundColor = self.color
+    func apply(to views : HeaderFooterContentViews<Self>, reason: ApplyReason) {
+        views.content.backgroundColor = self.color
     }
     
     func isEquivalent(to other: TestingHeaderFooterContent) -> Bool {
@@ -115,7 +115,7 @@ fileprivate struct TestingHeaderFooterContent : HeaderFooterContent {
     
     typealias ContentView = UIView
     
-    static func createReusableHeaderFooterView(frame: CGRect) -> UIView {
+    static func createReusableContentView(frame: CGRect) -> UIView {
         UIView(frame: frame)
     }
 }

--- a/Listable/Tests/ListView/ListView.VisibleContentTests.swift
+++ b/Listable/Tests/ListView/ListView.VisibleContentTests.swift
@@ -199,12 +199,12 @@ fileprivate struct TestHeaderFooter : HeaderFooterContent, Equatable
     
     typealias ContentView = UIView
     
-    func apply(to view: UIView, reason: ApplyReason)
+    func apply(to views : HeaderFooterContentViews<Self>, reason: ApplyReason)
     {
-        view.backgroundColor = self.color
+        views.content.backgroundColor = self.color
     }
     
-    static func createReusableHeaderFooterView(frame: CGRect) -> UIView {
+    static func createReusableContentView(frame: CGRect) -> UIView {
         UIView(frame: frame)
     }
 }

--- a/Listable/Tests/ListView/ListViewTests.swift
+++ b/Listable/Tests/ListView/ListViewTests.swift
@@ -76,11 +76,11 @@ fileprivate struct TestContent : ItemContent, Equatable
 
 fileprivate struct TestSupplementary : HeaderFooterContent, Equatable
 {
-    func apply(to view: UIView, reason: ApplyReason) {}
+    func apply(to views : HeaderFooterContentViews<Self>, reason: ApplyReason) {}
     
     typealias ContentView = UIView
 
-    static func createReusableHeaderFooterView(frame: CGRect) -> UIView
+    static func createReusableContentView(frame: CGRect) -> UIView
     {
         return UIView(frame: frame)
     }

--- a/README.md
+++ b/README.md
@@ -480,7 +480,13 @@ public protocol HeaderFooterContent
     func isEquivalent(to other : Self) -> Bool
     
     associatedtype ContentView:UIView
-    static func createReusableHeaderFooterView(frame : CGRect) -> ContentView
+    static func createReusableContentView(frame : CGRect) -> ContentView
+    
+    associatedtype BackgroundView:UIView
+    static func createReusableBackgroundView(frame : CGRect) -> BackgroundView
+    
+    associatedtype PressedBackgroundView:UIView
+    static func createReusablePressedBackgroundView(frame : CGRect) -> PressedBackgroundView
 }
 ```
 


### PR DESCRIPTION
This PR introduces support for tappable headers and footers, by adding an `onTap` handler to `HeaderFooter`. When provided, the header becomes tappable, and you can provide a `pressedBackgroundView` to appear, similar to the `selectedBackgroundView` of cells.

There's some unrelated changes to how zIndexing is done to improve determinism in layout, and there are also some fixes to bugs I found alongside this work.