### PR TITLE
Allow `ItemCell.ContentViewContainer` subviews to specify accessibility params

### DIFF
--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -98,6 +98,7 @@ struct DemoItem : BlueprintItemContent, Equatable
             $0.color = info.state.isActive ? .white : .darkGray
         }
         .inset(horizontal: 15.0, vertical: 10.0)
+        .accessibility(label: self.text, traits: [.button])
     }
     
     func backgroundElement(with info: ApplyItemContentInfo) -> Element?

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -157,6 +157,7 @@ final class SwipeActionsViewController: UIViewController  {
                 let separator = Inset(left: 16, wrapping: Rule(orientation: .horizontal, color: color))
                 column.add(growPriority: 0, shrinkPriority: 0, child: separator)
             }
+            .accessibility(label: "Swipeable item", value: item.title)
         }
     }
 

--- a/Listable/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/Listable/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -31,8 +31,6 @@ extension ItemCell {
 
             super.init(frame: frame)
 
-            isAccessibilityElement = true
-
             self.addSubview(self.contentView)
 
             NotificationCenter.default.addObserver(
@@ -223,8 +221,9 @@ extension ItemCell {
             }
         }
 
-        @objc private func performAccessibilityAction(_ action: AccessibilitySwipeAction) {
+        @objc private func performAccessibilityAction(_ action: AccessibilitySwipeAction) -> Bool {
             action.action.handler(self.didPerformAction)
+            return true
         }
 
         private func configureAccessibilityActions(for actions: [SwipeAction]) {

--- a/Listable/Tests/Internal/ItemCellTests.swift
+++ b/Listable/Tests/Internal/ItemCellTests.swift
@@ -23,6 +23,9 @@ class ItemElementCellTests : XCTestCase
         XCTAssertEqual(cell.contentView.layer.masksToBounds, false)
         
         XCTAssertEqual(cell.contentContainer.superview, cell.contentView)
+
+        // Ensure the content subviews can specify accessibility element params.
+        XCTAssertFalse(cell.contentContainer.isAccessibilityElement)
     }
     
     func test_sizeThatFits()


### PR DESCRIPTION
Don't set `isAccessibilityElement = true` for `ItemCell.ContentViewContainer`.

This fixes a couple of related bugs: 
* The content container's subviews could not specify accessibility parameters (e.g. labels, values, etc).
* Elements within the container could not be interacted with via Voiceover (e.g. swipe buttons).

Also:
* Add accessibility labels to demo app for testing
* Resolve a warning where the selector passed to `UIAccessibilityCustomAction.init` should return a bool
* Add a unit test

I tested on-device with Voiceover Rotor actions menu. Ensured that swipe actions and custom accessibility actions are still working as intended.

Demo:
https://youtu.be/dTTENavTYpc