### PR TITLE
Allow publishing to CocoaPods

### DIFF
--- a/BlueprintUILists.podspec
+++ b/BlueprintUILists.podspec
@@ -1,12 +1,12 @@
 
 Pod::Spec.new do |s|
   s.name         = 'BlueprintUILists'
-  s.version      = '0.9.0'
+  s.version      = '0.10.0'
   s.summary      = 'Declarative list views for iOS apps that deploy back to iOS 11.0.'
   s.homepage     = 'https://github.com/kyleve/Listable'
-  s.license      = { type: 'Proprietary', text: "© 2020 Square, Inc." }
-  s.author       = { 'iOS Team' => 'seller-ios@squareup.com' }
-  s.source       = { git: 'Not Published', tag: "podify/#{s.version}" }
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Kyle' => 'k@squareup.com' }
+  s.source       = { git: 'https://github.com/kyleve/Listable.git', tag: "#{s.version}" }
 
   s.ios.deployment_target = '11.0'
 
@@ -17,14 +17,19 @@ Pod::Spec.new do |s|
 
   s.source_files = 'BlueprintUILists/Sources/**/*.{swift}'
 
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'BlueprintUILists/Tests/**/*.{swift}'
-    test_spec.ios.resource_bundle = { 'BlueprintUIListsResources' => 'BlueprintUILists/Tests/Resources/**/*.*' }
+  unless ENV['LISTABLE_PUBLISHING']
 
-    test_spec.framework = 'XCTest'
-    
-    test_spec.libraries = 'swiftsimd', 'swiftCoreGraphics', 'swiftFoundation', 'swiftUIKit'
+   # These tests can only be run locally, because they depend on local pods.
 
-    test_spec.requires_app_host = true
+    s.test_spec 'Tests' do |test_spec|
+      test_spec.source_files = 'BlueprintUILists/Tests/**/*.{swift}'
+      test_spec.ios.resource_bundle = { 'BlueprintUIListsResources' => 'BlueprintUILists/Tests/Resources/**/*.*' }
+
+      test_spec.framework = 'XCTest'
+      
+      test_spec.libraries = 'swiftsimd', 'swiftCoreGraphics', 'swiftFoundation', 'swiftUIKit'
+
+      test_spec.requires_app_host = true
+    end
   end
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# Main
+# [Main]
+
+### Fixed
+
+### Added
+
+### Removed
+
+### Changed
+
+### Misc
+
+# Past Releases
+
+# [0.10.0] - 2020-09-24
 
 ### Fixed
 
@@ -20,11 +34,7 @@
 
 - Listable has been [renamed to ListableUI](https://github.com/kyleve/Listable/pull/211/), and BlueprintLists is now named BlueprintUILists. This is done to be more consistent with other Square UI libraries, and to avoid a conflict with an existing published Cocoapod, also named Listable.
 
-### Misc
-
-# Past Releases
-
-# 0.9.0
+# 0.9.0 - Internal Only
 
 ### Added
 
@@ -36,7 +46,7 @@
 
 - Changed [how `zIndexes` are assigned to header and items, and support tapping headers / footers](https://github.com/kyleve/Listable/pull/193). This allows registering an `onTap` handler for any HeaderFooter, and providing a background to display while the tap's press is active.
 
-## 0.8.0
+## 0.8.0 - Internal Only
 
 ### Added
 
@@ -79,7 +89,7 @@
 
 - [Significant refactors to how the custom layout APIs work.](https://github.com/kyleve/Listable/pull/178) While this is mostly an internal concern, it continues to refine these APIs to set them up for public exposure and usage at a later date to customize layouts.
 
-## 0.7.0
+## 0.7.0 - Internal Only
 
 ### Fixed
 
@@ -160,14 +170,14 @@
 
 ### Misc
 
-## 0.6.1
+## 0.6.1 - Internal Only
 
 ### Changed
 
 - Change `Item`'s `onSelect` and `onDeselect` [to be performed asynchronously](https://github.com/kyleve/Listable/pull/155) after a single runloop spin, to give `UICollectionView` time to schedule animations if these callbacks are slow.
 - Add improved signpost logging for selection and deselection, to more easily identify slow callbacks.
 
-## 0.6.0
+## 0.6.0 - Internal Only
 
 ### Fixed
 
@@ -187,12 +197,16 @@
 - `SelectionMode` [was moved from `Content` to `Behavior`](https://github.com/kyleve/Listable/pull/152), which is in line with other collection view behaviours like scrolling and underflow.
 - Rename `ItemSelectionStyle.none` to `ItemSelectionStyle.notSelectable`. This is to avoid conflicts with `Optional.none` when working with `ItemSelectionStyle` as an `Optional`.
 
-## 0.5.0
+## 0.5.0 - Internal Only
 
 ### Added
 
 - Added support for [conditionally scrolling to items](https://github.com/kyleve/Listable/pull/129) on insert, based on the `shouldPerform` block passed to the `AutoScrollAction`.
 
-## Earlier
+## Earlier - Internal Only
 
 Earlier releases were ad-hoc and not tracked. To see all changes, please reference [closed PRs on Github](https://github.com/kyleve/Listable/pulls?q=is%3Apr+is%3Aclosed).
+
+
+[Main]: https://github.com/square/Blueprint/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/square/Blueprint/compare/0.9.0...0.10.0

--- a/ListableUI.podspec
+++ b/ListableUI.podspec
@@ -1,12 +1,12 @@
 
 Pod::Spec.new do |s|
   s.name         = 'ListableUI'
-  s.version      = '0.9.0'
+  s.version      = '0.10.0'
   s.summary      = 'Declarative list views for iOS apps that deploy back to iOS 11.0.'
   s.homepage     = 'https://github.com/kyleve/Listable'
-  s.license      = { type: 'Proprietary', text: "© 2020 Square, Inc." }
-  s.author       = { 'iOS Team' => 'seller-ios@squareup.com' }
-  s.source       = { git: 'Not Published', tag: "podify/#{s.version}" }
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Kyle' => 'k@squareup.com' }
+  s.source       = { git: 'https://github.com/kyleve/Listable.git', tag: "#{s.version}" }
 
   s.ios.deployment_target = '11.0'
 
@@ -16,15 +16,20 @@ Pod::Spec.new do |s|
 
   s.weak_framework = 'SwiftUI'
 
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'ListableUI/Tests/**/*.{swift}'
-    test_spec.ios.resource_bundle = { 'ListableUITestsResources' => 'ListableUI/Tests/Resources/**/*.*' }
+  unless ENV['LISTABLE_PUBLISHING']
 
-    test_spec.framework = 'XCTest'
+    # These tests can only be run locally, because they depend on local pods.
 
-    test_spec.requires_app_host = true
+    s.test_spec 'Tests' do |test_spec|
+      test_spec.source_files = 'ListableUI/Tests/**/*.{swift}'
+      test_spec.ios.resource_bundle = { 'ListableUITestsResources' => 'ListableUI/Tests/Resources/**/*.*' }
 
-    test_spec.dependency 'EnglishDictionary'
-    test_spec.dependency 'Snapshot'
+      test_spec.framework = 'XCTest'
+
+      test_spec.requires_app_host = true
+
+      test_spec.dependency 'EnglishDictionary'
+      test_spec.dependency 'Snapshot'
+    end
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - BlueprintUI (0.12.2)
   - BlueprintUICommonControls (0.12.2):
     - BlueprintUI
-  - BlueprintUILists (0.9.0):
+  - BlueprintUILists (0.10.0):
     - BlueprintUI
     - ListableUI
-  - BlueprintUILists/Tests (0.9.0):
+  - BlueprintUILists/Tests (0.10.0):
     - BlueprintUI
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (0.9.0)
-  - ListableUI/Tests (0.9.0):
+  - ListableUI (0.10.0)
+  - ListableUI/Tests (0.10.0):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -45,9 +45,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 8b1c1cfd7ed73444ebfb66b54ad539cec6b600d9
   BlueprintUICommonControls: 31bfe6642633a1fde476bc566c565f5473343427
-  BlueprintUILists: 6cca110c66cb9b1c7dba7bc404dd5f5dc8e8b32e
+  BlueprintUILists: 77db62309844a70e5bfa33614404dd061c8921e7
   EnglishDictionary: f03968b9382ddc5c8dd63535efbf783c6cd45f1c
-  ListableUI: 9861809a460caeda70cb990a2029c0b37c13b8d1
+  ListableUI: db66bc8f100ac2b66af0a07504db4d81585781e9
   Snapshot: cda3414db426919d09f775434b36289c8e864183
 
 PODFILE CHECKSUM: c1209f66d9213201c70fd26a2f0907a6e29e8cbe

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,49 @@
+# Releasing a new version
+
+1. You must be listed as an owner of the pods `ListableUI` and `BlueprintUILists`.
+
+   To check this run:
+
+   ```bash
+   bundle exec pod trunk info ListableUI
+   bundle exec pod trunk info BlueprintUILists
+   ```
+
+   See [the CocoaPods documentation for pod trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk) for more information about setting up credentials on your device. If you need to be added as an owner, ping in #listable on Slack (Square only).
+
+1. Make sure you're on the `main` branch, and `git pull` to get the latest commits.
+
+1. Create a branch off `main` to update the version numbers and `Podfile.lock`. An example name would be `your-username/release-0.1.0`.
+
+1. Update the library version in both `ListableUI.podspec` and `BlueprintUILists.podspec` if it has not already been updated (it should match the version number that you are about to release).
+
+1. Update `CHANGELOG.md` (in the root of the repo), moving current changes under `Main` to a new section under `Past Releases` for the version you are releasing.
+  
+   The changelog uses [reference links](https://daringfireball.net/projects/markdown/syntax#link) to link each version's changes. Remember to add a link to the new version at the bottom of the file, and to update the link to `[main]`.
+
+1. Run `bundle exec pod install` to update the `Podfile.lock` with the new versions.
+
+1. Commit the podspec version bumps and the `Podfile.lock` update.
+   ```bash
+   git commit -am "Bumping versions to 0.1.0."
+   ```
+
+1. Push your branch and open a PR into `main`.
+
+1. Once the PR is merged, fetch changes and tag the release, using the merge commit:
+   ```bash
+   git fetch
+   git tag 0.1.0 <merge commit SHA>
+   git push origin 0.1.0
+   ```
+
+1. Publish to CocoaPods
+
+   Note: You may also need to quit Xcode before running these commands in order for the linting builds to succeed.
+
+   ```bash
+   LISTABLE_PUBLISHING=true bundle exec pod trunk push ListableUI.podspec
+   # The --synchronous argument ensures this command builds against the
+   # version of ListableUI that we just published.
+   LISTABLE_PUBLISHING=true bundle exec pod trunk push BlueprintUILists.podspec --synchronous
+   ```


### PR DESCRIPTION
This fixes various errors that broke publishing to cocoapods; which we can now do! Because the tests depend on local pods; I've wrapped those declarations in a check, and included instructions in the releasing.md, which is just a copy of blueprint's releasing info.