### PR TITLE
Add insets when using `.measureContent`

### DIFF
--- a/BlueprintUILists/Sources/List.swift
+++ b/BlueprintUILists/Sources/List.swift
@@ -82,7 +82,14 @@ public struct List : Element
                 return constraint.maximum
                 
             case .measureContent:
-                return ListView.contentSize(in: constraint.maximum, for: self.properties)
+                var size = ListView.contentSize(in: constraint.maximum, for: self.properties)
+                if let topInset = self.properties.scrollInsets.top {
+                    size.height += topInset
+                }
+                if let bottomInset = self.properties.scrollInsets.bottom {
+                    size.height += bottomInset
+                }
+                return size
             }
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Scroll insets are [now correctly included](https://github.com/kyleve/Listable/pull/221) when using the `measureContent` sizing with `List`.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
`contentSize` is just the content itself, and doesn’t include insets. This adds them in when measuring a `List` element.