### PR TITLE
Replace build with configure as parameter name.

### DIFF
--- a/BlueprintUILists/Sources/HeaderFooter.swift
+++ b/BlueprintUILists/Sources/HeaderFooter.swift
@@ -62,7 +62,7 @@ extension HeaderFooter
                 backgroundProvider: background,
                 pressedBackgroundProvider: pressedBackground
             ),
-            build: configure
+            configure: configure
         )
     }
     
@@ -113,7 +113,7 @@ extension HeaderFooter
                 backgroundProvider: background,
                 pressedBackgroundProvider: pressedBackground
             ),
-            build: configure
+            configure: configure
         )
     }
 }

--- a/BlueprintUILists/Sources/Item.swift
+++ b/BlueprintUILists/Sources/Item.swift
@@ -67,7 +67,7 @@ extension Item
                 backgroundProvider: background,
                 selectedBackgroundProvider: selectedBackground
             ),
-            build: configure
+            configure: configure
         )
     }
     
@@ -123,7 +123,7 @@ extension Item
                 backgroundProvider: background,
                 selectedBackgroundProvider: selectedBackground
             ),
-            build: configure
+            configure: configure
         )
     }
 }

--- a/BlueprintUILists/Sources/List.swift
+++ b/BlueprintUILists/Sources/List.swift
@@ -64,11 +64,11 @@ public struct List : Element
     /// configured with the provided `ListProperties` builder.
     public init(
         sizing : ListSizing = .fillParent,
-        build : ListProperties.Build
+        configure : ListProperties.Configure
     ) {
         self.sizing = sizing
         
-        self.properties = .default(with: build)
+        self.properties = .default(with: configure)
     }
     
     //

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- [Rename `build` parameters to `configure`](https://github.com/kyleve/Listable/pull/262), in order to be more consistent within the framework and with Blueprint.
+
 ### Misc
 
 # Past Releases

--- a/ListableUI/Sources/Content.swift
+++ b/ListableUI/Sources/Content.swift
@@ -81,14 +81,14 @@ public struct Content
     // MARK: Initialization
     //
     
-    public typealias Build = (inout Content) -> ()
+    public typealias Configure = (inout Content) -> ()
     
     /// Creates a new instance, configured as needed via the provided builder block.
-    public init(with build : Build)
+    public init(with configure : Configure)
     {
         self.init()
         
-        build(&self)
+        configure(&self)
     }
     
     /// Creates a new instance with the provided parameters.

--- a/ListableUI/Sources/EmbeddedList.swift
+++ b/ListableUI/Sources/EmbeddedList.swift
@@ -30,11 +30,11 @@ public extension Item where Content == EmbeddedList
     static func list<Identifier:Hashable>(
         _ identifier : Identifier,
         sizing : EmbeddedList.Sizing,
-        build : ListProperties.Build
+        configure : ListProperties.Configure
     ) -> Item<EmbeddedList>
     {
         Item(
-            EmbeddedList(identifier: identifier, build: build),
+            EmbeddedList(identifier: identifier, configure: configure),
             
             sizing: sizing.toStandardSizing,
             
@@ -68,7 +68,7 @@ public struct EmbeddedList : ItemContent
     // MARK: Initialization
     //
     
-    public init<Identifier:Hashable>(identifier : Identifier, build : ListProperties.Build)
+    public init<Identifier:Hashable>(identifier : Identifier, configure : ListProperties.Configure)
     {
         self.contentIdentifier = AnyHashable(identifier)
         
@@ -83,7 +83,7 @@ public struct EmbeddedList : ItemContent
             autoScrollAction: .none,
             accessibilityIdentifier: nil,
             debuggingIdentifier: nil,
-            build: build
+            configure: configure
         )
     }
     

--- a/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
@@ -28,15 +28,15 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     // MARK: Initialization
     //
     
-    public typealias Build = (inout HeaderFooter) -> ()
+    public typealias Configure = (inout HeaderFooter) -> ()
     
     public init(
         _ content : Content,
-        build : Build
+        configure : Configure
     ) {
         self.init(content)
         
-        build(&self)
+        configure(&self)
     }
     
     public init(

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -42,15 +42,15 @@ public struct Item<Content:ItemContent> : AnyItem
     // MARK: Initialization
     //
     
-    public typealias Build = (inout Item) -> ()
+    public typealias Configure = (inout Item) -> ()
     
     public init(
         _ content : Content,
-        build : Build
+        configure : Configure
     ) {
         self.init(content)
         
-        build(&self)
+        configure(&self)
     }
     
     public init(

--- a/ListableUI/Sources/ListProperties.swift
+++ b/ListableUI/Sources/ListProperties.swift
@@ -148,10 +148,10 @@ public struct ListProperties
     // MARK: Initialization
     //
 
-    public typealias Build = (inout ListProperties) -> ()
+    public typealias Configure = (inout ListProperties) -> ()
     
     /// An instance of `ListProperties` with sensible default values.
-    public static func `default`(with builder : Build = { _ in }) -> Self {
+    public static func `default`(with configure : Configure = { _ in }) -> Self {
         Self(
             animatesChanges: UIView.inheritedAnimationDuration > 0.0,
             layout: .table(),
@@ -161,7 +161,7 @@ public struct ListProperties
             autoScrollAction: .none,
             accessibilityIdentifier: nil,
             debuggingIdentifier: nil,
-            build: builder
+            configure: configure
         )
     }
     
@@ -175,7 +175,7 @@ public struct ListProperties
         autoScrollAction : AutoScrollAction,
         accessibilityIdentifier: String?,
         debuggingIdentifier: String?,
-        build : Build
+        configure : Configure
     ) {
         self.animatesChanges = animatesChanges
         self.layout = layout
@@ -191,7 +191,7 @@ public struct ListProperties
         
         self.stateObserver = ListStateObserver()
 
-        build(&self)
+        configure(&self)
     }
     
     //
@@ -199,14 +199,14 @@ public struct ListProperties
     //
     
     /// Updates the `ListProperties` object with the changes in the provided builder.
-    public mutating func modify(using builder : Build) {
-        builder(&self)
+    public mutating func modify(using configure : Configure) {
+        configure(&self)
     }
     
     /// Creates a new `ListProperties` object modified by the changes in the provided builder.
-    public func modified(using builder : Build) -> ListProperties {
+    public func modified(using configure : Configure) -> ListProperties {
         var copy = self
-        builder(&copy)
+        configure(&copy)
         return copy
     }
     

--- a/ListableUI/Sources/ListView/ListSizing.swift
+++ b/ListableUI/Sources/ListView/ListSizing.swift
@@ -69,7 +69,7 @@ extension ListView
     // MARK: Measuring Lists
     //
     
-    public static func contentSize(in fittingSize : CGSize, for properties : ListProperties.Build) -> CGSize {
+    public static func contentSize(in fittingSize : CGSize, for properties : ListProperties.Configure) -> CGSize {
         self.contentSize(in: fittingSize, for: .default(with: properties))
     }
     

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -558,7 +558,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
         })
     }
     
-    public func configure(with builder : ListProperties.Build)
+    public func configure(with configure : ListProperties.Configure)
     {
         let description = ListProperties(
             animatesChanges: true,
@@ -569,7 +569,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
             autoScrollAction: self.autoScrollAction,
             accessibilityIdentifier: self.collectionView.accessibilityIdentifier,
             debuggingIdentifier: self.debuggingIdentifier,
-            build: builder
+            configure: configure
         )
         
         self.configure(with: description)

--- a/ListableUI/Sources/ListViewSource.swift
+++ b/ListableUI/Sources/ListViewSource.swift
@@ -165,7 +165,7 @@ public final class StaticSource : ListViewSource
         self.content = content
     }
     
-    public convenience init(with builder : Content.Build)
+    public convenience init(with builder : Content.Configure)
     {
         self.init(with: Content(with: builder))
     }


### PR DESCRIPTION
This is more consistent within the framework, and with how Blueprint elements do it.