### PR TITLE
[SwipeActions] Limit overscrolling to the right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- [When swiping to delete](https://github.com/kyleve/Listable/pull/270), limit overscrolling to 20% of the cell width. This prevents undesirable visual state while maintaining swipe bounciness.
+- [When swiping to delete](https://github.com/kyleve/Listable/pull/270), limit overscrolling to 20% of the cell width. This prevents undesirable visual state while maintaining swipe bounciness. Additionally, ignore initial swipes to the right which do not "open" the cell.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- [When swiping to delete](https://github.com/kyleve/Listable/pull/270), limit overscrolling to 20% of the cell width. This prevents undesirable visual state while maintaining swipe bounciness.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -137,6 +137,7 @@ extension ItemCell {
 
             guard let configuration = swipeConfiguration else { return }
 
+            let velocity = sender.velocity(in: self).x
             let offsetMultiplier = configuration.numberOfActions == 1 ? 0.5 : 0.7
             let performActionOffset = frame.width * CGFloat(offsetMultiplier)
             let currentSwipeOffset = -contentView.frame.origin.x
@@ -152,14 +153,18 @@ extension ItemCell {
             switch sender.state {
             case .began, .changed:
 
-                let swipeState = SwipeActionState.swiping(willPerformAction: willPerformAction)
-                set(state: swipeState)
+                if swipeState == .closed && velocity > 0 {
+                    // The cell is closed and this is a swipe to the right. Ignore the swipe.
+                    sender.setTranslation(.zero, in: self)
+                } else {
+                    let swipeState = SwipeActionState.swiping(willPerformAction: willPerformAction)
+                    set(state: swipeState)
+                }
 
             case .ended, .cancelled:
 
                 let swipeActionsWidth = configuration.swipeView.swipeActionsWidth
                 let keepOpenOffset = swipeActionsWidth / 2
-                let velocity = sender.velocity(in: self).x
 
                 var swipeState: SwipeActionState
 

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -107,7 +107,7 @@ extension ItemCell {
                 insertSubview(swipeView, belowSubview: contentView)
                 swipeView.clipsToBounds = true
 
-                let panGestureRecognizer = HorizontalPanGestureRecognizer(target: self, action: #selector(handlePan))
+                let panGestureRecognizer = LeftPanGestureRecognizer(target: self, action: #selector(handlePan))
                 addGestureRecognizer(panGestureRecognizer)
 
                 swipeConfiguration = SwipeConfiguration(
@@ -137,7 +137,6 @@ extension ItemCell {
 
             guard let configuration = swipeConfiguration else { return }
 
-            let velocity = sender.velocity(in: self).x
             let offsetMultiplier = configuration.numberOfActions == 1 ? 0.5 : 0.7
             let performActionOffset = frame.width * CGFloat(offsetMultiplier)
             let currentSwipeOffset = -contentView.frame.origin.x
@@ -152,19 +151,14 @@ extension ItemCell {
 
             switch sender.state {
             case .began, .changed:
-
-                if swipeState == .closed && velocity > 0 {
-                    // The cell is closed and this is a swipe to the right. Ignore the swipe.
-                    sender.setTranslation(.zero, in: self)
-                } else {
-                    let swipeState = SwipeActionState.swiping(willPerformAction: willPerformAction)
-                    set(state: swipeState)
-                }
+                let swipeState = SwipeActionState.swiping(willPerformAction: willPerformAction)
+                set(state: swipeState)
 
             case .ended, .cancelled:
 
                 let swipeActionsWidth = configuration.swipeView.swipeActionsWidth
                 let keepOpenOffset = swipeActionsWidth / 2
+                let velocity = sender.velocity(in: self).x
 
                 var swipeState: SwipeActionState
 

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -68,7 +68,8 @@ extension ItemCell {
             case .swiping:
 
                 let translation = configuration.panGestureRecognizer.translation(in: self)
-                xOriginOffset = contentView.frame.origin.x + translation.x
+                // No actions exist to the left, so limit overscrolling to the right to 20% of the width.
+                xOriginOffset = min(bounds.width / 5.0, contentView.frame.origin.x + translation.x)
 
                 configuration.panGestureRecognizer.setTranslation(.zero, in: self)
 

--- a/ListableUI/Sources/Internal/LeftPanGestureRecognizer.swift
+++ b/ListableUI/Sources/Internal/LeftPanGestureRecognizer.swift
@@ -1,5 +1,5 @@
 //
-//  HorizontalPanGestureRecognizer.swift
+//  LeftPanGestureRecognizer.swift
 //  ListableUI
 //
 //  Created by Kyle Bashour on 4/21/20.
@@ -7,7 +7,8 @@
 
 import UIKit.UIGestureRecognizerSubclass
 
-class HorizontalPanGestureRecognizer: UIPanGestureRecognizer {
+/// `LeftPanGestureRecognizer` tracks horizontal swipes which begin to the left.
+final class LeftPanGestureRecognizer: UIPanGestureRecognizer {
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
 
@@ -18,6 +19,10 @@ class HorizontalPanGestureRecognizer: UIPanGestureRecognizer {
             let velocity = self.velocity(in: view)
 
             if abs(velocity.y) > abs(velocity.x) {
+                state = .cancelled
+            }
+
+            if velocity.x > 0 {
                 state = .cancelled
             }
         }


### PR DESCRIPTION
### Summary

Though Listable does not support actions beneath the left of the cell, it is currently possible to swipe the contents of a cell all the way to the right. This leads to unexpected and undesirable visual state.

This PR caps overscroll to the right to 20% of the width of the cell. As a result, we maintain a certain bounciness, but don't allow for wilder translations.

### Demo

**Before**
![before](https://user-images.githubusercontent.com/1542313/109522029-ebc42b00-7a7b-11eb-9c1a-c990df349bee.png)
https://user-images.githubusercontent.com/1542313/109521585-78221e00-7a7b-11eb-846c-c04962cf200d.mov

**After**
![after](https://user-images.githubusercontent.com/1542313/109522048-ef57b200-7a7b-11eb-9658-45f06d150f70.png)
https://user-images.githubusercontent.com/1542313/109521619-7fe1c280-7a7b-11eb-8676-d7b00faf1e4c.mov