### PR TITLE
Fix crash that occurs when transitioning to a zero size view, but better

### DIFF
--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -278,21 +278,22 @@ final class CollectionViewLayout : UICollectionViewLayout
         
         self.neededLayoutType.update(with: {
             
-            // Layouts with zero size are generally undefined, so skip them until the view has a size.
-            guard size.isEmpty == false else {
-                return false
-            }
+            // Layouts with zero area are undefined,
+            // so skip them until the view has a size.
+            let shouldLayout = size.isEmpty == false
             
             switch self.neededLayoutType {
             case .none: return true
             case .relayout: self.performLayout()
-            case .rebuild: self.performRebuild()
+            case .rebuild: self.performRebuild(andLayout: shouldLayout)
             }
             
             return true
         }())
         
         self.performLayoutUpdate()
+        
+        self.delegate.listViewLayoutDidLayoutContents()
     }
     
     override func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem])
@@ -317,7 +318,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Performing Layouts
     //
     
-    private func performRebuild()
+    private func performRebuild(andLayout layout : Bool)
     {
         self.previousLayout = self.layout
         
@@ -334,7 +335,9 @@ final class CollectionViewLayout : UICollectionViewLayout
             showsScrollIndicators: self.appearance.showsScrollIndicators
         )
                 
-        self.performLayout()
+        if layout {
+            self.performLayout()
+        }
     }
     
     private func performLayout()
@@ -531,6 +534,8 @@ public protocol CollectionViewLayoutDelegate : AnyObject
     func listLayoutContent(
         defaults: ListLayoutDefaults
     ) -> ListLayoutContent
+    
+    func listViewLayoutDidLayoutContents()
 }
 
 

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -216,6 +216,11 @@ extension ListView
                 environment: self.view.environment
             )
         }
+        
+        func listViewLayoutDidLayoutContents()
+        {
+            self.view.visibleContent.update(with: self.view)
+        }
 
         // MARK: UIScrollViewDelegate
         

--- a/ListableUI/Sources/ListView/ListView.VisibleContent.swift
+++ b/ListableUI/Sources/ListView/ListView.VisibleContent.swift
@@ -79,10 +79,6 @@ extension ListView
         
         private func calculateVisibleContent(in view : ListView) -> (Set<Item>, Set<HeaderFooter>)
         {
-            guard view.bounds.isEmpty == false else {
-                return ([], [])
-            }
-            
             let visibleFrame = view.collectionView.bounds
             
             let visibleAttributes = view.collectionViewLayout.visibleLayoutAttributesForElements(in: visibleFrame) ?? []

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -40,7 +40,10 @@ public final class ListView : UIView, KeyboardObserverDelegate
             behavior: self.behavior
         )
 
-        self.collectionView = CollectionView(frame: CGRect(origin: .zero, size: frame.size), collectionViewLayout: initialLayout)
+        self.collectionView = UICollectionView(
+            frame: CGRect(origin: .zero, size: frame.size),
+            collectionViewLayout: initialLayout
+        )
         
         self.layoutManager = LayoutManager(
             layout: initialLayout,
@@ -66,8 +69,6 @@ public final class ListView : UIView, KeyboardObserverDelegate
         super.init(frame: frame)
         
         // Associate ourselves with our child objects.
-
-        self.collectionView.view = self
 
         self.dataSource.presentationState = self.storage.presentationState
         self.dataSource.environment = self.environment
@@ -119,7 +120,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
     //
     
     let storage : Storage
-    let collectionView : CollectionView
+    let collectionView : UICollectionView
     let delegate : Delegate
     let layoutManager : LayoutManager
     let liveCells : LiveCells
@@ -846,10 +847,6 @@ public final class ListView : UIView, KeyboardObserverDelegate
         
         self.performBatchUpdates(with: diff, animated: reason.animated, updateBackingData: updateBackingData, completion: callerCompletion)
         
-        // Update the visible items.
-        
-        self.visibleContent.update(with: self)
-        
         // Perform any needed auto scroll actions.
         self.performAutoScrollAction(with: diff.changes.addedItemIdentifiers, animated: reason.animated)
 
@@ -1086,30 +1083,6 @@ extension ListView : ReorderingActionsDelegate
     func cancelInteractiveMovement()
     {
         self.collectionView.cancelInteractiveMovement()
-    }
-}
-
-
-extension ListView
-{
-    final class CollectionView : UICollectionView
-    {
-        weak var view : ListView?
-        
-        override func layoutSubviews() {
-            super.layoutSubviews()
-            
-            if let view = self.view {
-                ///
-                /// Update visibility of items and header / footers in the list view.
-                ///
-                /// This is intentionally performed in `layoutSubviews` of the `UICollectionView`,
-                /// **not** within `scrollViewDidScroll`. Why? `visibleContent.update(with:)`
-                /// depends on the collection view's layout, which is not updated until it `layoutSubviews`.
-                ///
-                view.visibleContent.update(with: view)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This PR is a follow-up to #271, and fixes the root issue that was causing the `VisibleContent` to get out of sync with the actual content in the list. Rather than the short-circuit fix, this PR:

- Removes the workaround from #271.
- Moves updating the visible content to when the content is actually re-laid out by the list, avoiding races, and ensuring the visible content is updated as soon as possible.
- Removes custom UICollectionView subclass, now that we can update at the right time.
- Fix a lingering issue where the collection view layout wouldn't re-build if the list had no area – leaving behind a stale layout. I need to write a test for this stll.