### PR TITLE
[ListActions] Add `scrollToSection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- [Adds `scrollToSection`](https://github.com/kyleve/Listable/pull/277) to `ListActions` and `ListView`. To support this functionality, `Section` can now be queried with an `Identifier`. Also added `SectionPosition` to specify the top or bottom within a `Section`. 
+
+Example usage:
+
+```
+listActions.scrolling.scrollToSection(
+  with: Identifier<Section>(id),
+  sectionPosition: .top,
+  scrollPosition: ScrollPosition(position: .centered)
+)
+```
+
 ### Removed
 
 ### Changed

--- a/ListableUI/Sources/Content.swift
+++ b/ListableUI/Sources/Content.swift
@@ -148,11 +148,11 @@ public struct Content
     /// Returns the first `IndexPath` for the contained `Item` with the given `AnyIdentifier`,
     /// if it can be found. If nothing is found, nil is returned.
     /// If you have multiple `Item`s with the same identifier, the first one will be returned.
-    public func firstIndexPathFor(itemIdentifier : AnyIdentifier) -> IndexPath?
+    public func firstIndexPathForItem(with identifier : AnyIdentifier) -> IndexPath?
     {
         for (sectionIndex, section) in self.sections.enumerated() {
             for (itemIndex, item) in section.items.enumerated() {
-                if item.identifier == itemIdentifier {
+                if item.identifier == identifier {
                     return IndexPath(item: itemIndex, section: sectionIndex)
                 }
             }
@@ -161,14 +161,14 @@ public struct Content
         return nil
     }
 
-    /// Returns the first `IndexPath` for the contained `Section` with the given `AnyIdentifier`,
+    /// Returns the first index position for the contained `Section` with the given `AnyIdentifier`,
     /// if it can be found. If nothing is found, nil is returned.
     /// If you have multiple `Section`s with the same identifier, the first one will be returned.
-    public func firstIndexPathFor(sectionIdentifier : AnyIdentifier) -> IndexPath?
+    public func firstIndexForSection(with identifier : AnyIdentifier) -> Int?
     {
         for (sectionIndex, section) in self.sections.enumerated() {
-            if section.identifier == sectionIdentifier {
-                return IndexPath(item: 0, section: sectionIndex)
+            if section.identifier == identifier {
+                return sectionIndex
             }
         }
 

--- a/ListableUI/Sources/Content.swift
+++ b/ListableUI/Sources/Content.swift
@@ -148,16 +148,30 @@ public struct Content
     /// Returns the first `IndexPath` for the contained `Item` with the given `AnyIdentifier`,
     /// if it can be found. If nothing is found, nil is returned.
     /// If you have multiple `Item`s with the same identifier, the first one will be returned.
-    public func firstIndexPath(for identifier : AnyIdentifier) -> IndexPath?
+    public func firstIndexPathFor(itemIdentifier : AnyIdentifier) -> IndexPath?
     {
         for (sectionIndex, section) in self.sections.enumerated() {
             for (itemIndex, item) in section.items.enumerated() {
-                if item.identifier == identifier {
+                if item.identifier == itemIdentifier {
                     return IndexPath(item: itemIndex, section: sectionIndex)
                 }
             }
         }
         
+        return nil
+    }
+
+    /// Returns the first `IndexPath` for the contained `Section` with the given `AnyIdentifier`,
+    /// if it can be found. If nothing is found, nil is returned.
+    /// If you have multiple `Section`s with the same identifier, the first one will be returned.
+    public func firstIndexPathFor(sectionIdentifier : AnyIdentifier) -> IndexPath?
+    {
+        for (sectionIndex, section) in self.sections.enumerated() {
+            if section.identifier == sectionIdentifier {
+                return IndexPath(item: 0, section: sectionIndex)
+            }
+        }
+
         return nil
     }
 

--- a/ListableUI/Sources/ListActions.swift
+++ b/ListableUI/Sources/ListActions.swift
@@ -133,6 +133,34 @@ public final class ListActions {
                 completion: completion
             )
         }
+
+        ///
+        /// Scrolls to the section with the provided identifier, with the provided positioning.
+        /// If there is more than one section with the same identifier, the list scrolls to the first.
+        /// If the section has content and is contained in the list, true is returned. If not, false is returned.
+        ///
+        /// The list will first attempt to scroll to the section header. If no header is present, it'll scroll to the
+        /// first item instead. If neither header nor items are found, the list will fallback to the footer.
+        ///
+        @discardableResult
+        public func scrollTo(
+            section : AnyIdentifier,
+            position : ScrollPosition,
+            animation : ScrollAnimation = .none,
+            completion : @escaping ScrollCompletion = { _ in }
+            ) -> Bool
+        {
+            guard let listView = self.listView else {
+                return false
+            }
+
+            return listView.scrollTo(
+                section: section,
+                position: position,
+                animation: animation,
+                completion: completion
+            )
+        }
         
         /// Scrolls to the very top of the list, which includes displaying the list header.
         @discardableResult

--- a/ListableUI/Sources/ListActions.swift
+++ b/ListableUI/Sources/ListActions.swift
@@ -135,28 +135,37 @@ public final class ListActions {
         }
 
         ///
-        /// Scrolls to the section with the provided identifier, with the provided positioning.
-        /// If there is more than one section with the same identifier, the list scrolls to the first.
-        /// If the section has content and is contained in the list, true is returned. If not, false is returned.
+        /// Scrolls to the section with the given identifier, with the provided scroll and section positioning.
         ///
-        /// The list will first attempt to scroll to the section header. If no header is present, it'll scroll to the
-        /// first item instead. If neither header nor items are found, the list will fallback to the footer.
+        /// If there is more than one section with the same identifier, the list scrolls to the first.
+        /// If the section has any content and is contained in the list, true is returned. If not, false is returned.
+        ///
+        /// The list will first attempt to scroll to the section's supplementary view
+        /// (header for `SectionPosition.top`, footer for `SectionPosition.bottom`).
+        ///
+        /// If not found, the list will scroll to the adjacent item instead
+        /// (section's first item for `.top`, last item for `.bottom`).
+        ///
+        /// If none of the above are present, the list will fallback to the remaining supplementary view
+        /// (footer for `.top`, header for `.bottom`).
         ///
         @discardableResult
-        public func scrollTo(
-            section : AnyIdentifier,
-            position : ScrollPosition,
-            animation : ScrollAnimation = .none,
+        public func scrollToSection(
+            with identifier : AnyIdentifier,
+            sectionPosition : SectionPosition = .top,
+            scrollPosition : ScrollPosition,
+            animation: ViewAnimation = .none,
             completion : @escaping ScrollCompletion = { _ in }
-            ) -> Bool
+        ) -> Bool
         {
             guard let listView = self.listView else {
                 return false
             }
 
-            return listView.scrollTo(
-                section: section,
-                position: position,
+            return listView.scrollToSection(
+                with: identifier,
+                sectionPosition: sectionPosition,
+                scrollPosition: scrollPosition,
                 animation: animation,
                 completion: completion
             )

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1001,9 +1001,9 @@ public final class ListView : UIView, KeyboardObserverDelegate
             new: new,
             configuration: SectionedDiff.Configuration(
                 section: .init(
-                    identifier: { $0.info.anyIdentifier },
+                    identifier: { $0.identifier },
                     items: { $0.items },
-                    movedHint: { $0.info.anyWasMoved(comparedTo: $1.info) }
+                    movedHint: { $0.identifier != $1.identifier }
                 ),
                 item: .init(
                     identifier: { $0.identifier },

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1015,6 +1015,13 @@ public final class ListView : UIView, KeyboardObserverDelegate
         completion : @escaping ScrollCompletion = { _ in }
     )
     {
+        // If the item is already visible and that's good enough, return.
+
+        let isAlreadyVisible = collectionView.contentFrame.contains(targetFrame)
+        if isAlreadyVisible && scrollPosition.ifAlreadyVisible == .doNothing {
+            return
+        }
+
         let topInset = collectionView.adjustedContentInset.top
         let contentFrameHeight = collectionView.contentFrame.height
         let adjustedOriginY = targetFrame.origin.y - topInset

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -390,7 +390,8 @@ public final class ListView : UIView, KeyboardObserverDelegate
     ///
     @discardableResult
     public func scrollTo(
-        item : AnyItem, position : ScrollPosition,
+        item : AnyItem,
+        position : ScrollPosition,
         animation: ViewAnimation = .none,
         completion : @escaping ScrollCompletion = { _ in }
     ) -> Bool
@@ -417,8 +418,8 @@ public final class ListView : UIView, KeyboardObserverDelegate
     ) -> Bool
     {
         // Make sure the item identifier is valid.
-        
-        guard let toIndexPath = self.storage.allContent.firstIndexPathFor(itemIdentifier: item) else {
+
+        guard let toIndexPath = self.storage.allContent.firstIndexPathForItem(with: item) else {
             return false
         }
         
@@ -450,82 +451,92 @@ public final class ListView : UIView, KeyboardObserverDelegate
     }
 
     ///
-    /// Scrolls to the section with the provided identifier, with the provided positioning.
-    /// If there is more than one section with the same identifier, the list scrolls to the first.
-    /// If the section has content and is contained in the list, true is returned. If not, false is returned.
+    /// Scrolls to the section with the given identifier, with the provided scroll and section positioning.
     ///
-    /// The list will first attempt to scroll to the section header. If no header is present, it'll scroll to the
-    /// first item instead. If neither header nor items are found, the list will fallback to the footer.
+    /// If there is more than one section with the same identifier, the list scrolls to the first.
+    /// If the section has any content and is contained in the list, true is returned. If not, false is returned.
+    ///
+    /// The list will first attempt to scroll to the section's supplementary view
+    /// (header for `SectionPosition.top`, footer for `SectionPosition.bottom`).
+    ///
+    /// If not found, the list will scroll to the adjacent item instead
+    /// (section's first item for `.top`, last item for `.bottom`).
+    ///
+    /// If none of the above are present, the list will fallback to the remaining supplementary view
+    /// (footer for `.top`, header for `.bottom`).
     ///
     @discardableResult
-    public func scrollTo(
-        section: AnyIdentifier,
-        position : ScrollPosition,
-        animation: ScrollAnimation = .none,
+    public func scrollToSection(
+        with identifier : AnyIdentifier,
+        sectionPosition : SectionPosition = .top,
+        scrollPosition : ScrollPosition,
+        animation: ViewAnimation = .none,
         completion : @escaping ScrollCompletion = { _ in }
     ) -> Bool
     {
         let storageContent = storage.allContent
-        let layoutContent = collectionViewLayout.layout.content
 
-        // Make sure the section identifier is valid and the section has content.
+        // Make sure the section identifier is valid.
 
-        guard let sectionPath = storageContent.firstIndexPathFor(sectionIdentifier: section),
-              layoutContent.sections[sectionPath.section].all.isEmpty == false
-        else {
+        guard let sectionIndex = storageContent.firstIndexForSection(with: identifier) else {
             return false
         }
 
-        let headerFrame = layoutContent.sections[sectionPath.section].header.defaultFrame
-        let footerFrame = layoutContent.sections[sectionPath.section].footer.defaultFrame
+        return preparePresentationStateForScrollToSection(index: sectionIndex) {
+            let layoutContent = self.collectionViewLayout.layout.content
 
-        func performScrollTo(targetFrame: CGRect, position: ScrollPosition.Position, at sectionPath: IndexPath) -> Bool
-        {
-            let topInset = collectionView.adjustedContentInset.top
-            let contentFrameHeight = collectionView.contentFrame.height
-            let adjustedOriginY = targetFrame.origin.y - topInset
+            // Make sure the section has content.
 
-            var resultOffset = collectionView.contentOffset
-
-            switch position {
-            case .top:
-                resultOffset.y = adjustedOriginY
-            case .centered:
-                resultOffset.y = adjustedOriginY - (contentFrameHeight / 2 - targetFrame.size.height / 2)
-            case .bottom:
-                resultOffset.y = adjustedOriginY - (contentFrameHeight - targetFrame.size.height)
+            guard layoutContent.sections[sectionIndex].all.isEmpty == false else {
+                return
             }
+            let header = layoutContent.sections[sectionIndex].header
+            let footer = layoutContent.sections[sectionIndex].footer
+            let items = storageContent.sections[sectionIndex].items
 
-            // Don't scroll past the bottom of the list.
+            let targetSupplementaryView = (sectionPosition == .top) ? header : footer
+            let fallbackSupplementaryView = (sectionPosition == .top) ? footer : header
+            let adjacentItem = (sectionPosition == .top) ? items.first : items.last
 
-            let maxOffsetHeight = collectionViewLayout.collectionViewContentSize.height - contentFrameHeight - topInset
-            resultOffset.y = min(resultOffset.y, maxOffsetHeight)
+            // Prevent the footer from appearing underneath a sticky section header.
 
-            // Don't scroll beyond the top of the list.
+            let footerFrameAdjustedForStickyHeaders: CGRect? = {
+                guard sectionPosition == .bottom,
+                      self.collectionViewLayout.layout.stickySectionHeaders,
+                      scrollPosition.position == .top
+                else {
+                    return nil
+                }
+                return CGRect(
+                    x: footer.x,
+                    y: footer.y - header.size.height,
+                    width: footer.size.width,
+                    height: footer.size.height
+                )
+            }()
 
-            resultOffset.y = max(resultOffset.y, -topInset)
-
-            return preparePresentationStateForScroll(to: sectionPath) {
-                animation.perform(
-                    animations: {
-                        self.collectionView.setContentOffset(resultOffset, animated: false)
-                    },
+            if targetSupplementaryView.isPopulated {
+                self.performScroll(
+                    to: footerFrameAdjustedForStickyHeaders ?? targetSupplementaryView.defaultFrame,
+                    scrollPosition: scrollPosition,
+                    animation: animation,
+                    completion: completion
+                )
+            } else if let adjacentItem = adjacentItem {
+                self.scrollTo(
+                    item: adjacentItem,
+                    position: scrollPosition,
+                    animation: animation,
+                    completion: completion
+                )
+            } else {
+                self.performScroll(
+                    to: fallbackSupplementaryView.defaultFrame,
+                    scrollPosition: scrollPosition,
+                    animation: animation,
                     completion: completion
                 )
             }
-        }
-
-        if headerFrame.height != 0 {
-            // Scroll to header if present.
-            return performScrollTo(targetFrame: headerFrame, position: position.position, at: sectionPath)
-
-        } else if let firstSectionItem = storageContent.sections[sectionPath.section].items.first {
-            // If not, scroll to first item if present.
-            return scrollTo(item: firstSectionItem, position: position)
-
-        } else {
-            // Otherwise, fallback to footer.
-            return performScrollTo(targetFrame: footerFrame, position: position.position, at: sectionPath)
         }
     }
     
@@ -959,7 +970,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
         } else {
             switch self.autoScrollAction {
             case .scrollToItem(let insertInfo):
-                let itemPath = self.storage.allContent.firstIndexPathFor(itemIdentifier: insertInfo.insertedIdentifier)
+                let itemPath = self.storage.allContent.firstIndexPathForItem(with: insertInfo.insertedIdentifier)
                 guard let autoScrollIndexPath = itemPath else {
                     fallthrough
                 }
@@ -997,12 +1008,78 @@ public final class ListView : UIView, KeyboardObserverDelegate
         }
     }
 
+    private func performScroll(
+        to targetFrame : CGRect,
+        scrollPosition : ScrollPosition,
+        animation: ViewAnimation = .none,
+        completion : @escaping ScrollCompletion = { _ in }
+    )
+    {
+        let topInset = collectionView.adjustedContentInset.top
+        let contentFrameHeight = collectionView.contentFrame.height
+        let adjustedOriginY = targetFrame.origin.y - topInset
+
+        var resultOffset = collectionView.contentOffset
+
+        switch scrollPosition.position {
+        case .top:
+            resultOffset.y = adjustedOriginY
+        case .centered:
+            resultOffset.y = adjustedOriginY - (contentFrameHeight / 2 - targetFrame.size.height / 2)
+        case .bottom:
+            resultOffset.y = adjustedOriginY - (contentFrameHeight - targetFrame.size.height)
+        }
+
+        // Don't scroll past the bottom of the list.
+
+        let maxOffsetHeight = collectionViewLayout.collectionViewContentSize.height - contentFrameHeight - topInset
+        resultOffset.y = min(resultOffset.y, maxOffsetHeight)
+
+        // Don't scroll beyond the top of the list.
+
+        resultOffset.y = max(resultOffset.y, -topInset)
+
+        animation.perform(
+            animations: {
+                self.collectionView.setContentOffset(resultOffset, animated: false)
+            },
+            completion: completion
+        )
+    }
+
     private func preparePresentationStateForScroll(to toIndexPath: IndexPath, scroll: @escaping () -> Void) -> Bool {
+
+        // Make sure we have a last loaded index path.
+
+        guard let lastLoadedIndexPath = self.storage.presentationState.lastIndexPath else {
+            return false
+        }
 
         // Update presentation state if needed, then scroll.
 
-        if let lastLoadedIndexPath = self.storage.presentationState.lastIndexPath,
-           lastLoadedIndexPath < toIndexPath {
+        if lastLoadedIndexPath < toIndexPath {
+            self.updatePresentationState(for: .programaticScrollDownTo(toIndexPath)) { _ in
+                scroll()
+            }
+        } else {
+            scroll()
+        }
+
+        return true
+    }
+
+    private func preparePresentationStateForScrollToSection(index: Int, scroll: @escaping () -> Void) -> Bool {
+
+        // Make sure section is contained within all content.
+
+        guard index < storage.allContent.sections.count else {
+            return false
+        }
+
+        // Update presentation state if needed, then scroll.
+
+        if index >= storage.presentationState.sections.count {
+            let toIndexPath = IndexPath(item: 0, section: index)
             self.updatePresentationState(for: .programaticScrollDownTo(toIndexPath)) { _ in
                 scroll()
             }

--- a/ListableUI/Sources/Section/Section.swift
+++ b/ListableUI/Sources/Section/Section.swift
@@ -12,9 +12,8 @@ public struct Section
     // MARK: Public Properties
     //
     
-    /// Data backing the identity and updates to the section – for example
-    /// if the section has been moved, plus the identifier for the section's content.
-    public var info : AnySectionInfo
+    /// The value which uniquely identifies the section within a list.
+    public var identifier : Identifier<Section>
     
     /// The header, if any, associated with the section.
     public var header : AnyHeaderFooter?
@@ -64,19 +63,9 @@ public struct Section
     //
     
     public typealias Configure = (inout Section) -> ()
-        
-    public init<Info:SectionInfo>(
-        _ info: Info,
-        configure : Configure
-        )
-    {
-        self.init(info)
-        
-        configure(&self)
-    }
     
-    public init<Identifier:Hashable>(
-        _ identifier : Identifier,
+    public init<IdentifierType:Hashable>(
+        _ identifier : IdentifierType,
         layouts : SectionLayouts = .init(),
         header : AnyHeaderFooter? = nil,
         footer : AnyHeaderFooter? = nil,
@@ -84,25 +73,7 @@ public struct Section
         configure : Configure = { _ in }
         )
     {
-        self.init(
-            HashableSectionInfo(identifier),
-            header: header,
-            footer: footer,
-            items: items,
-            configure: configure
-        )
-    }
-    
-    public init<Info:SectionInfo>(
-        _ info: Info,
-        layouts : SectionLayouts = .init(),
-        header : AnyHeaderFooter? = nil,
-        footer : AnyHeaderFooter? = nil,
-        items : [AnyItem] = [],
-        configure : Configure = { _ in }
-        )
-    {
-        self.info = info
+        self.identifier = Identifier<Section>(identifier)
         
         self.layouts = layouts
         
@@ -166,68 +137,5 @@ public struct Section
         let end = min(self.items.count, limit)
         
         return Array(self.items[0..<end])
-    }
-}
-
-
-public protocol SectionInfo : AnySectionInfo
-{
-    //
-    // MARK: Identifying Content & Changes
-    //
-    
-    var identifier : Identifier<Self> { get }
-    
-    func wasMoved(comparedTo other : Self) -> Bool
-}
-
-
-public protocol AnySectionInfo
-{
-    //
-    // MARK: Identifying Content & Changes
-    //
-    
-    var anyIdentifier : AnyIdentifier { get }
-    
-    func anyWasMoved(comparedTo other : AnySectionInfo) -> Bool
-}
-
-
-public extension SectionInfo
-{
-    var anyIdentifier : AnyIdentifier {
-        self.identifier
-    }
-    
-    func anyWasMoved(comparedTo other : AnySectionInfo) -> Bool
-    {
-        guard let other = other as? Self else {
-            return true
-        }
-        
-        return self.wasMoved(comparedTo: other)
-    }
-}
-
-
-private struct HashableSectionInfo<Value:Hashable> : SectionInfo
-{
-    var value : Value
-    
-    init(_ value : Value)
-    {
-        self.value = value
-    }
-    
-    // MARK: SectionInfo
-    
-    var identifier : Identifier<HashableSectionInfo> {
-        return .init(self.value)
-    }
-    
-    func wasMoved(comparedTo other : HashableSectionInfo) -> Bool
-    {
-        return self.value != other.value
     }
 }

--- a/ListableUI/Sources/Section/SectionPosition.swift
+++ b/ListableUI/Sources/Section/SectionPosition.swift
@@ -1,0 +1,17 @@
+//
+//  SectionPosition.swift
+//  ListableUI
+//
+//  Created by Ian Luo on 3/10/21.
+//
+
+/// Specifies the supplementary views and / or items based on position within a `Section`.
+///
+public enum SectionPosition : Equatable
+{
+    /// Represents the header and / or first item(s) within a section.
+    case top
+
+    /// Represents the footer and / or last item(s) within a section.
+    case bottom
+}


### PR DESCRIPTION
Add capability to scroll to the section with the provided identifier, with the provided positioning.

The list will first attempt to scroll to the section header. If no header is present, it'll scroll to the first item instead. If neither header nor items are found, the list will fallback to the footer.

Also:
* Renamed the `firstIndexPath` function in `Content.swift` to differentiate between querying with an `itemIdentifier` and a `sectionIdentifier`.
* Cherry-picked @kyleve's [commit](https://github.com/kyleve/Listable/pull/276) to remove `SectionInfo` in favor of using identifier directly on `Section`.

Example usage: 
```
listActions.scrolling.scrollTo(
    section: Identifier<Section>(5),
    position: ScrollPosition(position: .centered)
)
```

Produces the following behavior:

![listable_demo](https://user-images.githubusercontent.com/2940471/110370827-090b7300-8001-11eb-967d-86ca4d367c50.gif)
