### PR TITLE
Fix `scrollToItem` appearing underneath sticky header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- When calling `scrollToItem` with a `.top` scroll position, [the item no longer appears underneath sticky section headers](https://github.com/kyleve/Listable/pull/279). 
+
 ### Added
 
 - [Adds `scrollToSection`](https://github.com/kyleve/Listable/pull/277) to `ListActions` and `ListView`. To support this functionality, `Section` can now be queried with an `Identifier`. Also added `SectionPosition` to specify the top or bottom within a `Section`. 


### PR DESCRIPTION
When a `top` scroll position is used, the item will appear underneath the sticky section header.
Now, we adjust the frame and use a manual content offset when sticky headers are enabled.

When sticky headers are disabled or scrolling to a different position, we call the existing `scrollToItem` function on UICollectionView.

Note this PR depends on the `performScrollToTargetFrame` function added in https://github.com/kyleve/Listable/pull/277, so that one will need to be merged before this one builds.

-----------------------------------------------------------


Example scrolling to Row # 50, 2:

**Before:**
-----------------------------------------------------------

![scroll_to_item_not_fixed](https://user-images.githubusercontent.com/2940471/110990944-daefa100-8328-11eb-8940-277c5d8c7fb2.gif)

-----------------------------------------------------------

**After:**
-----------------------------------------------------------

![scroll_to_item_fixed](https://user-images.githubusercontent.com/2940471/110990959-de832800-8328-11eb-9720-b67e55268820.gif)
