### PR TITLE
Add automatic RefreshControl offset adjustment behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ### Fixed
 
 ### Added
+- Add support for adjusting the content offset when the refresh control becomes visible with the `offsetAdjustmentBehavior` property.
+
+Example usage:
+
+```
+list.content.refreshControl = RefreshControl(
+    isRefreshing: isRefreshing,
+    offsetAdjustmentBehavior: .displayWhenRefreshing(animate: true),
+    onRefresh: onRefresh
+)
+```
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Example usage:
 ```
 list.content.refreshControl = RefreshControl(
     isRefreshing: isRefreshing,
-    offsetAdjustmentBehavior: .displayWhenRefreshing(animate: true),
+    offsetAdjustmentBehavior: .displayWhenRefreshing(animate: true, scrollToTop: true),
     onRefresh: onRefresh
 )
 ```

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		0AEB96B922FBCBA600341DFF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AEB96B822FBCBA600341DFF /* Assets.xcassets */; };
 		0AEB96BC22FBCBA600341DFF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AEB96BA22FBCBA600341DFF /* LaunchScreen.storyboard */; };
 		0AEB96E222FBCC1D00341DFF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEB96D322FBCC1D00341DFF /* AppDelegate.swift */; };
+		1F46FB6B26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46FB6A26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift */; };
 		27B4DCE9244F88BE001BA9D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27B4DCE8244F88BE001BA9D9 /* Assets.xcassets */; };
 		2B8804652490844A003BB351 /* SpacingCustomizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */; };
 		397F72040272B0B12CAD9AEE /* Pods_Test_Targets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF78F98F7ED38C2DC8078110 /* Pods_Test_Targets.framework */; };
@@ -87,6 +88,7 @@
 		0AEB96BB22FBCBA600341DFF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0AEB96BD22FBCBA600341DFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0AEB96D322FBCC1D00341DFF /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		1F46FB6A26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshControlOffsetAdjustmentViewController.swift; sourceTree = "<group>"; };
 		27B4DCE8244F88BE001BA9D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacingCustomizationViewController.swift; sourceTree = "<group>"; };
 		A1C03134338F55F7FD12551D /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -150,6 +152,7 @@
 				0AD6767925423BE500A49315 /* MultiSelectViewController.swift */,
 				0AC2A1952489F93E00779459 /* PagedViewController.swift */,
 				0AA4D9B7248064A300CF95A5 /* ReorderingViewController.swift */,
+				1F46FB6A26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift */,
 				0AA4D9AA248064A200CF95A5 /* ScrollViewEdgesPlaygroundViewController.swift */,
 				0A793B5724E4B53500850139 /* ManualSelectionManagementViewController.swift */,
 				2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */,
@@ -437,6 +440,7 @@
 			files = (
 				0AA4D9BE248064A300CF95A5 /* DemosRootViewController.swift in Sources */,
 				0AA4D9C2248064A300CF95A5 /* HorizontalLayoutViewController.swift in Sources */,
+				1F46FB6B26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift in Sources */,
 				0AA4D9C6248064A300CF95A5 /* SwipeActionsViewController.swift in Sources */,
 				0AA4D9BF248064A300CF95A5 /* WidthCustomizationViewController.swift in Sources */,
 				0AA4D9C8248064A300CF95A5 /* ReorderingViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/RefreshControlOffsetAdjustmentViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/RefreshControlOffsetAdjustmentViewController.swift
@@ -1,0 +1,85 @@
+//
+//  RefreshControlOffsetAdjustmentViewController.swift
+//  Demo
+//
+//  Created by Alexis Akers on 3/16/21.
+//  Copyright © 2021 Kyle Van Essen. All rights reserved.
+//
+
+import UIKit
+
+import UIKit
+import ListableUI
+import BlueprintUI
+import BlueprintUICommonControls
+import BlueprintUILists
+
+final class RefreshControlOffsetAdjustmentViewController : UIViewController
+{
+    private let blueprintView = BlueprintView()
+    private var isRefreshing: Bool = false
+
+    // MARK: - Views
+
+    override func loadView()
+    {
+        self.view = self.blueprintView
+        reloadData()
+        updateNavigationItems()
+    }
+
+    private func updateNavigationItems()
+    {
+        if isRefreshing {
+            navigationItem.rightBarButtonItems = [
+                UIBarButtonItem(title: "Stop Refreshing", style: .plain, target: self, action: #selector(stopRefreshing)),
+            ]
+        } else {
+            navigationItem.rightBarButtonItems = [
+                UIBarButtonItem(title: "Refresh", style: .plain, target: self, action: #selector(refresh)),
+            ]
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc func refresh()
+    {
+        isRefreshing = true
+        reloadData()
+        updateNavigationItems()
+    }
+
+    @objc func stopRefreshing()
+    {
+        isRefreshing = false
+        reloadData()
+        updateNavigationItems()
+    }
+
+    // MARK: - Content
+
+    func reloadData()
+    {
+        blueprintView.element = List { list in
+            list.layout = .table {
+                $0.layout.padding.top = 24.0
+                $0.layout.itemSpacing = 10.0
+            }
+
+            list.content.refreshControl = RefreshControl(
+                isRefreshing: isRefreshing,
+                offsetAdjustmentBehavior: .displayWhenRefreshing(animate: true),
+                onRefresh: { [weak self] in
+                    self?.refresh()
+                }
+            )
+
+            list += Section("section") { section in
+                section += DemoItem(text: "Item 1")
+                section += DemoItem(text: "Item 2")
+                section += DemoItem(text: "Item 3")
+            }
+        }
+    }
+}

--- a/Demo/Sources/Demos/Demo Screens/RefreshControlOffsetAdjustmentViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/RefreshControlOffsetAdjustmentViewController.swift
@@ -18,6 +18,7 @@ final class RefreshControlOffsetAdjustmentViewController : UIViewController
 {
     private let blueprintView = BlueprintView()
     private var isRefreshing: Bool = false
+    private var enableScrollToTop: Bool = false
 
     // MARK: - Views
 
@@ -30,18 +31,33 @@ final class RefreshControlOffsetAdjustmentViewController : UIViewController
 
     private func updateNavigationItems()
     {
+        var items: [UIBarButtonItem] = [
+            UIBarButtonItem(
+                title: "Scroll to top: \(enableScrollToTop ? "ON" : "OFF")",
+                style: .plain,
+                target: self, action: #selector(toggleScrollToTop))
+        ]
+
         if isRefreshing {
-            navigationItem.rightBarButtonItems = [
-                UIBarButtonItem(title: "Stop Refreshing", style: .plain, target: self, action: #selector(stopRefreshing)),
-            ]
+            items.append(
+                UIBarButtonItem(title: "Stop Refreshing", style: .plain, target: self, action: #selector(stopRefreshing))
+            )
         } else {
-            navigationItem.rightBarButtonItems = [
-                UIBarButtonItem(title: "Refresh", style: .plain, target: self, action: #selector(refresh)),
-            ]
+            items.append(
+                UIBarButtonItem(title: "Refresh", style: .plain, target: self, action: #selector(refresh))
+            )
         }
+
+        navigationItem.rightBarButtonItems = items
     }
 
     // MARK: - Actions
+
+    @objc func toggleScrollToTop()
+    {
+        enableScrollToTop.toggle()
+        updateNavigationItems()
+    }
 
     @objc func refresh()
     {
@@ -63,22 +79,24 @@ final class RefreshControlOffsetAdjustmentViewController : UIViewController
     {
         blueprintView.element = List { list in
             list.layout = .table {
-                $0.layout.padding.top = 24.0
+                $0.layout.padding = UIEdgeInsets(top: 24, left: 16, bottom: 24, right: 16)
                 $0.layout.itemSpacing = 10.0
             }
 
             list.content.refreshControl = RefreshControl(
                 isRefreshing: isRefreshing,
-                offsetAdjustmentBehavior: .displayWhenRefreshing(animate: true),
+                offsetAdjustmentBehavior: .displayWhenRefreshing(animate: true, scrollToTop: enableScrollToTop),
                 onRefresh: { [weak self] in
                     self?.refresh()
                 }
             )
 
             list += Section("section") { section in
-                section += DemoItem(text: "Item 1")
-                section += DemoItem(text: "Item 2")
-                section += DemoItem(text: "Item 3")
+                section.items = (1 ... 100).map {
+                    Item(
+                        DemoItem(text: "Item \($0)")
+                    )
+                }
             }
         }
     }

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -116,6 +116,13 @@ public final class DemosRootViewController : ListViewController
                 onSelect : { _ in
                     self.push(InvoicesPaymentScheduleDemoViewController())
             })
+
+            section += Item(
+                DemoItem(text: "Refresh Control"),
+                selectionStyle: .selectable(),
+                onSelect : { _ in
+                    self.push(RefreshControlOffsetAdjustmentViewController())
+            })
             
             section += Item(
                 DemoItem(text: "Swipe Actions"),

--- a/ListableUI/Sources/Internal/Presentation State/PresentationState.swift
+++ b/ListableUI/Sources/Internal/Presentation State/PresentationState.swift
@@ -276,9 +276,30 @@ final class PresentationState
             let newControl = RefreshControlState(new)
             view.refreshControl = newControl.view
             self.refreshControl = newControl
+            newControl.update(with: new)
         } else if self.refreshControl != nil, new == nil {
             view.refreshControl = nil
             self.refreshControl = nil
+        }
+    }
+
+    internal func adjustContentOffsetForRefreshControl(in view : UIScrollView)
+    {
+        guard
+            let control = refreshControl,
+            control.model.isRefreshing == true
+        else {
+            return
+        }
+
+        switch control.model.offsetAdjustmentBehavior {
+        case .displayWhenRefreshing(let animate):
+            let contentOffset = CGPoint(x: 0, y: -control.view.frame.height - view.safeAreaInsets.top)
+            view.setContentOffset(contentOffset, animated: animate)
+            control.view.beginRefreshing()
+
+        case .none:
+            return
         }
     }
     

--- a/ListableUI/Sources/Internal/Presentation State/PresentationState.swift
+++ b/ListableUI/Sources/Internal/Presentation State/PresentationState.swift
@@ -285,10 +285,7 @@ final class PresentationState
 
     internal func adjustContentOffsetForRefreshControl(in view : UIScrollView)
     {
-        guard
-            let control = refreshControl,
-            control.model.isRefreshing == true
-        else {
+        guard let control = refreshControl, control.model.isRefreshing else {
             return
         }
 

--- a/ListableUI/Sources/Internal/Presentation State/PresentationState.swift
+++ b/ListableUI/Sources/Internal/Presentation State/PresentationState.swift
@@ -290,10 +290,14 @@ final class PresentationState
         }
 
         switch control.model.offsetAdjustmentBehavior {
-        case .displayWhenRefreshing(let animate):
-            let contentOffset = CGPoint(x: 0, y: -control.view.frame.height - view.safeAreaInsets.top)
+        case .displayWhenRefreshing(let animate, let scrollToTop):
+            // If we are not scrolled to the top or don't enable scroll to top, don't do anything
+            guard view.isScrolledToTop || scrollToTop else {
+                return
+            }
+
+            let contentOffset = CGPoint(x: 0, y: -view.adjustedContentInset.top)
             view.setContentOffset(contentOffset, animated: animate)
-            control.view.beginRefreshing()
 
         case .none:
             return
@@ -452,5 +456,20 @@ extension PresentationState
                 )
             }
         )
+    }
+}
+
+fileprivate extension UIScrollView
+{
+    var isScrolledToTop: Bool
+    {
+        // adjustedContentInset includes the refresh control height, subtract that to
+        // get the top point at rest
+        var topInset = adjustedContentInset.top
+        if let refreshControl = self.refreshControl {
+            topInset -= refreshControl.frame.height
+        }
+
+        return contentOffset.y <= -topInset
     }
 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -954,7 +954,10 @@ public final class ListView : UIView, KeyboardObserverDelegate
         // Update Collection View
         
         self.performBatchUpdates(with: diff, animated: reason.animated, updateBackingData: updateBackingData, completion: callerCompletion)
-        
+
+        // Update the offset of the scroll view to show the refresh control if needed
+        presentationState.adjustContentOffsetForRefreshControl(in: self.collectionView)
+
         // Perform any needed auto scroll actions.
         self.performAutoScrollAction(with: diff.changes.addedItemIdentifiers, animated: reason.animated)
 

--- a/ListableUI/Sources/RefreshControl.swift
+++ b/ListableUI/Sources/RefreshControl.swift
@@ -46,7 +46,7 @@ extension RefreshControl
     public enum OffsetAdjustmentBehavior : Equatable
     {
         case none
-        case displayWhenRefreshing(animate: Bool)
+        case displayWhenRefreshing(animate: Bool, scrollToTop: Bool)
     }
 
     public enum Title : Equatable

--- a/ListableUI/Sources/RefreshControl.swift
+++ b/ListableUI/Sources/RefreshControl.swift
@@ -10,8 +10,11 @@ import Foundation
 
 public struct RefreshControl
 {
+
     public var isRefreshing : Bool
-    
+
+    public var offsetAdjustmentBehavior: OffsetAdjustmentBehavior
+
     public var title : Title?
     
     public var tintColor : UIColor?
@@ -21,12 +24,14 @@ public struct RefreshControl
     
     public init(
         isRefreshing: Bool,
+        offsetAdjustmentBehavior: OffsetAdjustmentBehavior = .none,
         title : Title? = nil,
         tintColor : UIColor? = nil,
         onRefresh : @escaping OnRefresh
         )
     {
         self.isRefreshing = isRefreshing
+        self.offsetAdjustmentBehavior = offsetAdjustmentBehavior
 
         self.title = title
         self.tintColor = tintColor
@@ -38,6 +43,12 @@ public struct RefreshControl
 
 extension RefreshControl
 {
+    public enum OffsetAdjustmentBehavior : Equatable
+    {
+        case none
+        case displayWhenRefreshing(animate: Bool)
+    }
+
     public enum Title : Equatable
     {
         case string(String)


### PR DESCRIPTION
### Goal
When `RefreshControl.isRefreshing` becomes `true` because of a change of state that is not caused by the user pulling to refresh (for example changing filters or tapping retry from an error cell), we want to be able to display the refresh control to indicate that loading is in progress.

### Implementation Details
- We add an offsetAdjustmentBehavior property to `RefreshControl ` to allow consumers to opt into this behavior 
- Create a `adjustContentOffsetForRefreshControl` method in `PresentationState` to adjust the offset based on the current state of the refresh control
- Call that method from `updatePresentationState` in `ListView` after content updates and before performing any auto scroll actions

### Demo
**iOS 12**

https://user-images.githubusercontent.com/16192914/111357445-b3b60e00-865f-11eb-8b1c-9836820ad898.mov

**iOS 13**

https://user-images.githubusercontent.com/16192914/111358304-90d82980-8660-11eb-932a-d4d7a024ffd6.mov

**iOS 14**

https://user-images.githubusercontent.com/16192914/111358454-b9f8ba00-8660-11eb-84a4-fb2da50c9335.mov
