### PR TITLE
Fix Reordering Crash

### DIFF
--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -188,7 +188,7 @@ struct Toggle : Element {
         {
             super.init(frame: frame)
             
-            self.addTarget(self, action: #selector(toggled), for: .valueChanged)
+            self.addTarget(self, action: #selector(didToggleValue), for: .valueChanged)
         }
         
         @available(*, unavailable)
@@ -196,7 +196,7 @@ struct Toggle : Element {
             fatalError()
         }
         
-        @objc func toggled()
+        @objc func didToggleValue()
         {
             self.onToggle(self.isOn)
         }

--- a/Demo/Sources/Demos/Demo Screens/PaymentTypesViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/PaymentTypesViewController.swift
@@ -16,6 +16,7 @@ final class PaymentTypesViewController : ListViewController {
         
         list.layout = .table { table in
             table.layout.interSectionSpacingWithNoFooter = 10.0
+            table.layout.padding.bottom = 100
         }
         
         let types = self.types
@@ -48,9 +49,15 @@ final class PaymentTypesViewController : ListViewController {
             
             section.header = HeaderFooter(PaymentTypeHeader(title: SectionID.disabled.title))
             
+            section.reordering.minItemCount = 0
+            
             section += types.filter { $0.isEnabled == false }
             .sorted { $0.sortOrder < $1.sortOrder }
             .map(makeItem(with:))
+            
+            if section.items.isEmpty {
+                section += EmptyRow()
+            }
         }
     }
     
@@ -128,6 +135,25 @@ fileprivate struct PaymentTypeHeader : BlueprintHeaderFooterContent, Equatable {
     var elementRepresentation: Element {
         Label(text: title) {
             $0.font = .systemFont(ofSize: 18.0, weight: .medium)
+        }
+        .inset(uniform: 15.0)
+    }
+    
+    var background: Element? {
+        Box(backgroundColor: .white)
+    }
+}
+
+fileprivate struct EmptyRow : BlueprintItemContent, Equatable {
+    
+    var identifierValue: String {
+        ""
+    }
+    
+    func element(with info: ApplyItemContentInfo) -> Element {
+        Label(text: "No Contents") {
+            $0.font = .systemFont(ofSize: 16.0, weight: .semibold)
+            $0.color = .lightGray
         }
         .inset(uniform: 15.0)
     }

--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -162,9 +162,7 @@ final class CollectionViewLayout : UICollectionViewLayout
         let context = context as! InvalidationContext
         
         // Handle Moved Items
-        
-        self.isReordering = context.interactiveMoveAction != nil
-        
+                
         if let action = context.interactiveMoveAction {
             
             switch action {
@@ -229,6 +227,8 @@ final class CollectionViewLayout : UICollectionViewLayout
         previousPosition: CGPoint
     ) -> UICollectionViewLayoutInvalidationContext
     {
+        self.isReordering = true
+        
         let context = super.invalidationContext(
             forInteractivelyMovingItems: targetIndexPaths,
             withTargetPosition: targetPosition,
@@ -254,6 +254,8 @@ final class CollectionViewLayout : UICollectionViewLayout
         movementCancelled: Bool
     ) -> UICollectionViewLayoutInvalidationContext
     {
+        self.isReordering = false
+        
         let context = super.invalidationContextForEndingInteractiveMovementOfItems(
             toFinalIndexPaths: indexPaths,
             previousIndexPaths: previousIndexPaths,
@@ -391,9 +393,12 @@ final class CollectionViewLayout : UICollectionViewLayout
             let shouldLayout = size.isEmpty == false
             
             switch self.neededLayoutType {
-            case .none: return true
-            case .relayout: self.performLayout()
-            case .rebuild: self.performRebuild(andLayout: shouldLayout)
+            case .none:
+                return true
+            case .relayout:
+                self.performLayout()
+            case .rebuild:
+                self.performRebuild(andLayout: shouldLayout)
             }
             
             return true

--- a/ListableUI/Sources/ListView/ListChangesQueue.swift
+++ b/ListableUI/Sources/ListView/ListChangesQueue.swift
@@ -1,0 +1,99 @@
+//
+//  ListChangesQueue.swift
+//  ListableUI
+//
+//  Created by Kyle Van Essen on 7/19/21.
+//
+
+import Foundation
+
+
+/// Used to queue updates into a list view.
+/// Note: This type is only safe to use from the main thread.
+final class ListChangesQueue {
+        
+    /// Adds a synchronous block to the queue, marked as done once the block exits.
+    func add(_ block : @escaping () -> ()) {
+        self.waiting.append(.init(block))
+        self.runIfNeeded()
+    }
+    
+    /// Set by consumers to enable and disable queueing during a reorder event.
+    var isQueuingForReorderEvent : Bool = false {
+        didSet {
+            self.runIfNeeded()
+        }
+    }
+    
+    /// Prevents processing other events in the queue.
+    ///
+    /// Note: Right now this just checks `isQueuingForReorderEvent`, but may check more props in the future.
+    var isPaused : Bool {
+        self.isQueuingForReorderEvent
+    }
+    
+    /// Operations waiting to execute.
+    private(set) var waiting : [Operation] = []
+    
+    /// Invoked to continue processing queue events.
+    private func runIfNeeded() {
+        precondition(Thread.isMainThread)
+        
+        /// Nothing to do if we're currently paused!
+        guard self.isPaused == false else {
+            return
+        }
+        
+        while let next = self.waiting.popFirst() {
+            autoreleasepool {
+                guard case .new(let new) = next.state else {
+                    fatalError("State of enqueued operation was wrong")
+                }
+                
+                /// Ok, we have a runnable operation; let's run it.
+                
+                next.state = .done
+                
+                new.body()
+            }
+        }
+    }
+}
+
+
+extension ListChangesQueue {
+    
+    final class Operation {
+        
+        fileprivate(set) var state : State
+        
+        init(_ body : @escaping () -> ()) {
+            self.state = .new(.init(body: body))
+        }
+        
+        enum State {
+            case new(New)
+            case done
+            
+            struct New {
+                let body : () -> ()
+            }
+        }
+    }
+}
+
+
+fileprivate extension Array {
+    
+    mutating func popFirst() -> Element? {
+        guard self.isEmpty == false else {
+            return nil
+        }
+        
+        let first = self[0]
+        
+        self.remove(at: 0)
+        
+        return first
+    }
+}

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -97,6 +97,16 @@ internal extension ListView
                 return
             }
             
+            ///
+            /// Mark us as queuing for re-orders, to prevent destructive edits which could break the collection
+            /// view's layout while the re-order event settles.
+            ///
+            /// Later on, the call to `listViewShouldEndQueueingEditsForReorder` will set this value to false.
+            ///
+            /// See `sendEndQueuingEditsAfterDelay` for a more in-depth explanation.
+            ///
+            self.view.updateQueue.isQueuingForReorderEvent = true
+            
             /// Perform the change in our data source.
             
             self.storage.moveItem(from: from, to: to)

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -261,9 +261,12 @@ extension ListView
             )
         }
         
-        func listViewLayoutDidLayoutContents()
-        {
+        func listViewLayoutDidLayoutContents() {
             self.view.visibleContent.update(with: self.view)
+        }
+        
+        func listViewShouldEndQueueingEditsForReorder() {
+            self.view.updateQueue.isQueuingForReorderEvent = false
         }
 
         // MARK: UIScrollViewDelegate

--- a/ListableUI/Tests/ListView/ListChangesQueueTests.swift
+++ b/ListableUI/Tests/ListView/ListChangesQueueTests.swift
@@ -1,0 +1,53 @@
+//
+//  ListChangesQueueTests.swift
+//  ListableUI-Unit-Tests
+//
+//  Created by Kyle Van Essen on 7/24/21.
+//
+
+import XCTest
+@testable import ListableUI
+
+
+class ListChangesQueueTests : XCTestCase {
+    
+    func test_queue() {
+        
+        let queue = ListChangesQueue()
+        
+        XCTAssertFalse(queue.isPaused)
+        XCTAssertFalse(queue.isQueuingForReorderEvent)
+        
+        var calls : [Int] = []
+        
+        queue.add {
+            calls += [1]
+        }
+        
+        XCTAssertEqual(queue.waiting.count, 0)
+        XCTAssertEqual(calls, [1])
+        
+        queue.isQueuingForReorderEvent = true
+        
+        XCTAssertTrue(queue.isPaused)
+        XCTAssertTrue(queue.isQueuingForReorderEvent)
+        
+        queue.add {
+            calls += [2]
+        }
+        
+        queue.add {
+            calls += [3]
+        }
+        
+        XCTAssertEqual(queue.waiting.count, 2)
+        XCTAssertEqual(calls, [1])
+        
+        queue.isQueuingForReorderEvent = false
+        
+        XCTAssertFalse(queue.isPaused)
+        XCTAssertFalse(queue.isQueuingForReorderEvent)
+        
+        XCTAssertEqual(calls, [1, 2, 3])
+    }
+}


### PR DESCRIPTION
This adds a queue that we can stop during re-order events; to prevent the case that a row is removed as the result of signalling to listeners that a re-order happened – which the collection view doesn't does not internally handle.