### PR TITLE
Enable horizontal scroll actions.

### DIFF
--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -457,7 +457,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
                 } else {
                     self.collectionView.scrollToItem(
                         at: toIndexPath,
-                        at: position.position.UICollectionViewScrollPosition,
+                        at: position.position.toUICollectionViewScrollPosition(for: self.collectionViewLayout.layout.direction),
                         animated: false
                     )
                 }

--- a/ListableUI/Sources/ScrollPosition.swift
+++ b/ListableUI/Sources/ScrollPosition.swift
@@ -49,11 +49,20 @@ extension ScrollPosition
         /// Scroll the item to the bottom of the list.
         case bottom
         
-        var UICollectionViewScrollPosition : UICollectionView.ScrollPosition {
-            switch self {
-            case .top: return .top
-            case .centered: return .centeredVertically
-            case .bottom: return .bottom
+        func toUICollectionViewScrollPosition(for direction : LayoutDirection) -> UICollectionView.ScrollPosition {
+            switch direction {
+            case .vertical:
+                switch self {
+                case .top: return .top
+                case .centered: return .centeredVertically
+                case .bottom: return .bottom
+                }
+            case .horizontal:
+                switch self {
+                case .top: return .left
+                case .centered: return .centeredHorizontally
+                case .bottom: return .right
+                }
             }
         }
     }


### PR DESCRIPTION
#### Goal
Currently scrolling to an item using ListAction doesn't work with horizontal orientation because `ScrollPosition.Position` doesn't cover all available UIKit options.

#### Implementation Details
We return top, bottom and centeredVerically for vertical layouts and left, right and centeredHorizontally for horizontal.
