### PR TITLE
Fix supplementary reuse bug by ensuring we track the right view instance in our displayed views cache

### DIFF
--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
@@ -14,8 +14,8 @@ extension PresentationState
     {
         var model : Section
         
-        var header : HeaderFooterViewStatePair
-        var footer : HeaderFooterViewStatePair
+        let header : HeaderFooterViewStatePair
+        let footer : HeaderFooterViewStatePair
         
         var items : [AnyPresentationItemState]
         

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
@@ -16,10 +16,10 @@ final class PresentationState
         
     var refreshControl : RefreshControlState?
     
-    var containerHeader : HeaderFooterViewStatePair
-    var header : HeaderFooterViewStatePair
-    var footer : HeaderFooterViewStatePair
-    var overscrollFooter : HeaderFooterViewStatePair
+    let containerHeader : HeaderFooterViewStatePair
+    let header : HeaderFooterViewStatePair
+    let footer : HeaderFooterViewStatePair
+    let overscrollFooter : HeaderFooterViewStatePair
     
     var sections : [PresentationState.SectionState]
     

--- a/ListableUI/Sources/Internal/SupplementaryContainerView.swift
+++ b/ListableUI/Sources/Internal/SupplementaryContainerView.swift
@@ -64,6 +64,8 @@ final class SupplementaryContainerView : UICollectionReusableView
         ) as! SupplementaryContainerView
         
         view.reuseCache = reuseCache
+        
+        // TODO: We need to also set this during on-screen updates; I don't think it's updated correctly now.
         view.environment = environment
         
         return view

--- a/ListableUI/Sources/Internal/SupplementaryContainerView.swift
+++ b/ListableUI/Sources/Internal/SupplementaryContainerView.swift
@@ -73,7 +73,7 @@ final class SupplementaryContainerView : UICollectionReusableView
     // MARK: Content
     //
     
-    var headerFooter : AnyPresentationHeaderFooterState? {
+    weak var headerFooter : AnyPresentationHeaderFooterState? {
         didSet {
             guard oldValue !== self.headerFooter else {
                 return

--- a/ListableUI/Sources/Internal/SupplementaryContainerView.swift
+++ b/ListableUI/Sources/Internal/SupplementaryContainerView.swift
@@ -75,7 +75,7 @@ final class SupplementaryContainerView : UICollectionReusableView
     // MARK: Content
     //
     
-    weak var headerFooter : AnyPresentationHeaderFooterState? {
+    var headerFooter : AnyPresentationHeaderFooterState? {
         didSet {
             guard oldValue !== self.headerFooter else {
                 return

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -163,7 +163,7 @@ extension ListView
             
             headerFooter.willDisplay(view: container)
             
-            self.displayedSupplementaryItems[ObjectIdentifier(view)] = headerFooter
+            self.displayedSupplementaryItems[ObjectIdentifier(container)] = headerFooter
         }
         
         func collectionView(

--- a/ListableUI/Tests/Internal/SupplementaryContainerViewTests.swift
+++ b/ListableUI/Tests/Internal/SupplementaryContainerViewTests.swift
@@ -89,7 +89,9 @@ class SupplementaryContainerViewTests: XCTestCase
         
         // Add a header
         
-        view.headerFooter = self.newHeaderFooter()
+        let header = self.newHeaderFooter()
+        
+        view.headerFooter = header
         view.sizeToFit()
         
         // Make sure the view is set


### PR DESCRIPTION
This PR fixes a bug introduced in #288 (well sort of, 288 uncovered the actual bug):

A long time ago, a method argument was renamed from `view` to `anyView`, which meant we were no longer shadowing the `view` variable on the `Delegate`:

```
        func collectionView(
            _ collectionView: UICollectionView,
                                         // Was renamed from `view`.
            willDisplaySupplementaryView anyView: UICollectionReusableView,
            forElementKind kindString: String,
            at indexPath: IndexPath
            )
        {
            let container = anyView as! SupplementaryContainerView
            let kind = SupplementaryKind(rawValue: kindString)!
            
            let headerFooter : PresentationState.HeaderFooterViewStatePair = ...

            headerFooter.willDisplay(view: container)

          - self.displayedSupplementaryItems[ObjectIdentifier(view)] = headerFooter
          + self.displayedSupplementaryItems[ObjectIdentifier(container)] = headerFooter
```

So the fix here was to properly pass the `ObjectIdentifier` of the `container`, not `view` (`self.view` is actually the `ListView`).

Without this change, `didEndDisplay()` was never invoked on the header/footer (because `displayedSupplementaryItems` is used to track what is being used by the collection view), meaning we never cleared out values during view reuse, which broke the next time a view was reused if the view type was different.