### PR TITLE
Weakify headerFooter on SupplementaryContainerView.swift to avoid a retain cycle

### DIFF
--- a/ListableUI/Sources/Internal/SupplementaryContainerView.swift
+++ b/ListableUI/Sources/Internal/SupplementaryContainerView.swift
@@ -73,7 +73,7 @@ final class SupplementaryContainerView : UICollectionReusableView
     // MARK: Content
     //
     
-    var headerFooter : AnyPresentationHeaderFooterState? {
+    weak var headerFooter : AnyPresentationHeaderFooterState? {
         didSet {
             guard oldValue !== self.headerFooter else {
                 return


### PR DESCRIPTION
NOTE: Depends on #321 making it into `main`.