### PR TITLE
Prepare 0.27.1, change .thatFits defaults for Item and HeaderFooter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 # Past Releases
 
+# [0.27.1] - 2021-09-28
+
+### Changed
+
+- [Change the default sizing of `Item` and `HeaderFooter`](https://github.com/kyleve/Listable/pull/331) to `.thatFits(.noConstraint)` from requiring the min from the layout. This is more common for self-sizing cells.
+
 # [0.27.0] - 2021-09-15
 
 ### Changed
@@ -466,7 +472,8 @@ listActions.scrolling.scrollToSection(
 Earlier releases were ad-hoc and not tracked. To see all changes, please reference [closed PRs on Github](https://github.com/kyleve/Listable/pulls?q=is%3Apr+is%3Aclosed).
 
 
-[Main]: https://github.com/kyleve/Listable/compare/0.27.0...HEAD
+[Main]: https://github.com/kyleve/Listable/compare/0.27.1...HEAD
+[0.27.1]: https://github.com/kyleve/Listable/compare/0.27.0...0.27.1
 [0.27.0]: https://github.com/kyleve/Listable/compare/0.26.1...0.27.0
 [0.26.1]: https://github.com/kyleve/Listable/compare/0.26.0...0.26.1
 [0.26.0]: https://github.com/kyleve/Listable/compare/0.25.1...0.26.0

--- a/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
@@ -51,7 +51,7 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
         
         let defaults = self.content.defaultHeaderFooterProperties
         
-        self.sizing = finalValue(from: sizing, defaults.sizing, .thatFits(.init(.atLeast(.default))))
+        self.sizing = finalValue(from: sizing, defaults.sizing, .thatFits(.noConstraint))
         self.layouts = finalValue(from: layouts, defaults.layouts, .init())
         
         self.onTap = onTap

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -80,7 +80,7 @@ public struct Item<Content:ItemContent> : AnyItem
         
         let defaults = self.content.defaultItemProperties
         
-        self.sizing = finalValue(from: sizing, defaults.sizing, .thatFits(.init(.atLeast(.default))))
+        self.sizing = finalValue(from: sizing, defaults.sizing, .thatFits(.noConstraint))
         self.layouts = finalValue(from: layouts, defaults.layouts, .init())
         self.selectionStyle = finalValue(from: selectionStyle, defaults.selectionStyle, .notSelectable)
         self.insertAndRemoveAnimations = finalValue(from: insertAndRemoveAnimations, defaults.insertAndRemoveAnimations, nil)

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - BlueprintUI (0.27.0)
   - BlueprintUICommonControls (0.27.0):
     - BlueprintUI
-  - BlueprintUILists (0.27.0):
+  - BlueprintUILists (0.27.1):
     - BlueprintUI
     - ListableUI
-  - BlueprintUILists/Tests (0.27.0):
+  - BlueprintUILists/Tests (0.27.1):
     - BlueprintUI
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (0.27.0)
-  - ListableUI/Tests (0.27.0):
+  - ListableUI (0.27.1)
+  - ListableUI/Tests (0.27.1):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -45,9 +45,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 0fe7dfb34d43c8ff1b6b69ca1bce853fa1eda084
   BlueprintUICommonControls: e228bcd0a6918d52465d300a0dbce0bceaab4674
-  BlueprintUILists: 9581f98b50e883720213b4ba60280738fd69cc57
+  BlueprintUILists: ebd97919f9f0ca3c6e3b10363b1e2aeb80ecff17
   EnglishDictionary: f03968b9382ddc5c8dd63535efbf783c6cd45f1c
-  ListableUI: 85feef72fcab80041be85c5727522f9a804d049d
+  ListableUI: 401c343ac52ae312cf41b4803cbc24ea06bb2956
   Snapshot: cda3414db426919d09f775434b36289c8e864183
 
 PODFILE CHECKSUM: 505f47e09640e9b7eadef9a138cfeed056359f76

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-LISTABLE_VERSION ||= '0.27.0'
+LISTABLE_VERSION ||= '0.27.1'


### PR DESCRIPTION
This `.thatFits` default of defaulting to the minimum from the layout didn't make a lot of sense, since all cells (in practice) are self-sizing.