### PR TITLE
Introduce AnyHeaderFooterConvertible, so it's less verbose to create headers and footers with default values

### DIFF
--- a/BlueprintUILists/Sources/List.swift
+++ b/BlueprintUILists/Sources/List.swift
@@ -18,13 +18,13 @@ import ListableUI
 /// on `ListView` itself.
 /// ```
 /// List { list in
-///     list.content.header = HeaderFooter(PodcastsHeader())
+///     list.content.header = PodcastsHeader()
 ///
 ///     let podcasts = Podcast.podcasts.sorted { $0.episode < $1.episode }
 ///
 ///     list += Section("podcasts") { section in
 ///
-///         section.header = HeaderFooter(PodcastsSectionHeader())
+///         section.header = PodcastsSectionHeader()
 ///
 ///         section += podcasts.map { podcast in
 ///             PodcastRow(podcast: podcast)

--- a/BlueprintUILists/Tests/ListTests.swift
+++ b/BlueprintUILists/Tests/ListTests.swift
@@ -24,13 +24,13 @@ class ListTests : XCTestCase {
         
         view.element = List { list in
             
-            list.content.header = HeaderFooter(TestHeaderContent(wasCalled: callback))
-            list.content.footer = HeaderFooter(TestHeaderContent(wasCalled: callback))
+            list.content.header = TestHeaderContent(wasCalled: callback)
+            list.content.footer = TestHeaderContent(wasCalled: callback)
             
             list("section") { section in
                 
-                section.header = HeaderFooter(TestHeaderContent(wasCalled: callback))
-                section.footer = HeaderFooter(TestHeaderContent(wasCalled: callback))
+                section.header = TestHeaderContent(wasCalled: callback)
+                section.footer = TestHeaderContent(wasCalled: callback)
                 
                 section += TestItemContent(wasCalled: callback)
                 section += TestItemContent(wasCalled: callback)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ### Changed
 
+- [Introduced `AnyHeaderFooterConvertible` for `HeaderFooters`](https://github.com/kyleve/Listable/pull/332) contained in lists and sections, so you no longer need to wrap your `HeaderFooterContent` in a `HeaderFooter` to receive default values. Eg, you can now do:
+    
+    ```swift
+    section.header = MyHeaderContent(title: "Albums")
+    ```
+    
+    Instead of:
+
+    ```swift
+    section.header = HeaderFooter(MyHeaderContent(title: "Albums"))
+    ```
+
 ### Misc
 
 # Past Releases

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -66,13 +66,13 @@ struct DemoHeader : BlueprintHeaderFooterContent, Equatable
     
     var elementRepresentation: Element {
         Label(text: self.title) {
-            $0.font = .systemFont(ofSize: 20.0, weight: .bold)
+            $0.font = .systemFont(ofSize: 21.0, weight: .bold)
         }
-        .inset(horizontal: 15.0, vertical: 10.0)
+        .inset(horizontal: 15.0, vertical: 15.0)
         .box(
             background: .white,
             corners: .rounded(radius: 10.0),
-            shadow: .simple(radius: 2.0, opacity: 0.2, offset: .init(width: 0.0, height: 1.0), color: .black)
+            shadow: .simple(radius: 1.0, opacity: 0.15, offset: CGSize(width: 0, height: 1), color: .black)
         )
     }
 }
@@ -83,13 +83,12 @@ struct DemoHeader2 : BlueprintHeaderFooterContent, Equatable
     
     var elementRepresentation: Element {
         Label(text: self.title) {
-            $0.font = .systemFont(ofSize: 20.0, weight: .bold)
+            $0.font = .systemFont(ofSize: 21.0, weight: .bold)
         }
         .inset(horizontal: 15.0, vertical: 30.0)
         .box(
             background: .white,
-            corners: .rounded(radius: 10.0),
-            shadow: .simple(radius: 2.0, opacity: 0.2, offset: .init(width: 0.0, height: 1.0), color: .black)
+            corners: .rounded(radius: 10.0)
         )
     }
 }
@@ -111,7 +110,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
             row.verticalAlignment = .center
             
             row.add(child: Label(text: self.text) {
-                $0.font = .systemFont(ofSize: 16.0, weight: .medium)
+                $0.font = .systemFont(ofSize: 17.0, weight: .medium)
                 $0.color = info.state.isActive ? .white : .darkGray
             })
             
@@ -127,7 +126,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
                 )
             }
         }
-        .inset(horizontal: 15.0, vertical: 10.0)
+        .inset(horizontal: 15.0, vertical: 13.0)
         .accessibility(label: self.text, traits: [.button])
     }
     
@@ -135,13 +134,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
     {
         Box(
             backgroundColor: .white,
-            cornerStyle: .rounded(radius: 8.0),
-            shadowStyle: .simple(
-                radius: info.state.isReordering ? 5.0 : 2.0,
-                opacity: info.state.isReordering ? 0.5 : 0.15,
-                offset: .init(width: 0.0, height: 1.0),
-                color: .black
-            )
+            cornerStyle: .rounded(radius: 8.0)
         )
     }
     

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewBasicDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewBasicDemoViewController.swift
@@ -54,9 +54,7 @@ final class CollectionViewBasicDemoViewController : UIViewController
         listView.configure { list in
             
             if self.showsOverscrollFooter {
-                list.content.overscrollFooter = HeaderFooter(
-                    DemoHeader(title: "Thanks for using Listable!!")
-                )
+                list.content.overscrollFooter = DemoHeader(title: "Thanks for using Listable!!")
             }
             
             list.animatesChanges = animated
@@ -67,15 +65,12 @@ final class CollectionViewBasicDemoViewController : UIViewController
                     section.layouts.table.columns = .init(count: 2, spacing: 10.0)
                      
                     if self.showsSectionHeaders {
-                        section.header = HeaderFooter(DemoHeader(title: "Section Header"))
+                        section.header = DemoHeader(title: "Section Header")
                     } else {
-                        section.header = HeaderFooter(DemoHeader2(title: "Section Header"))
+                        section.header = DemoHeader2(title: "Section Header")
                     }
                     
-                    section.footer = HeaderFooter(
-                        DemoFooter(text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi non luctus sem, eu consectetur ipsum. Curabitur malesuada cursus ante."),
-                        sizing: .thatFits()
-                    )
+                    section.footer = DemoFooter(text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi non luctus sem, eu consectetur ipsum. Curabitur malesuada cursus ante.")
                     
                     section += sectionRows
                 }

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewDictionaryDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewDictionaryDemoViewController.swift
@@ -109,7 +109,7 @@ final public class CollectionViewDictionaryDemoViewController : UIViewController
                 return Section(letter.letter) { section in
                     
                     // Set the header.
-                    section.header = HeaderFooter(SectionHeader(title: letter.letter))
+                    section.header = SectionHeader(title: letter.letter)
                     
                     // Only include word rows that pass the filter.
                     section += letter.words.compactMap { word in

--- a/Demo/Sources/Demos/Demo Screens/CustomLayoutsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/CustomLayoutsViewController.swift
@@ -31,7 +31,7 @@ final class CustomLayoutsViewController : UIViewController
 
             list += Section("default") { section in
                 
-                section.header = HeaderFooter(DemoHeader(title: "Some Rows"))
+                section.header = DemoHeader(title: "Some Rows")
                 
                 section += Item(
                     DemoItem(text: "Row 1"),

--- a/Demo/Sources/Demos/Demo Screens/InvoicesPaymentScheduleDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/InvoicesPaymentScheduleDemoViewController.swift
@@ -79,15 +79,9 @@ final class InvoicesPaymentScheduleDemoViewController : UIViewController
             if self.data.requestsInitialDeposit {
                 list += Section(SectionIdentifier.deposits) { section in
                     
-                    section.header = HeaderFooter(
-                        SectionHeader(text: "Deposit Request"),
-                        sizing: .thatFits()
-                    )
+                    section.header = SectionHeader(text: "Deposit Request")
                     
-                    section.footer = HeaderFooter(
-                        SectionFooter(text: "Request $10.00 deposit on $100.00 invoice."),
-                        sizing: .thatFits()
-                    )
+                    section.footer = SectionFooter(text: "Request $10.00 deposit on $100.00 invoice.")
                     
                     section += Item(
                         SegmentedControlRow(id: "split-type") { control in
@@ -124,15 +118,9 @@ final class InvoicesPaymentScheduleDemoViewController : UIViewController
             if self.data.splitsIntoMilestones {
                 list += Section(SectionIdentifier.splits) { section in
                     
-                    section.header = HeaderFooter(
-                        SectionHeader(text: "Balance Split"),
-                        sizing: .thatFits()
-                    )
+                    section.header = SectionHeader(text: "Balance Split")
                     
-                    section.footer = HeaderFooter(
-                        SectionFooter(text: "Request $90.00 of $100.00 invoice balance over 2 payments."),
-                        sizing: .thatFits()
-                    )
+                    section.footer = SectionFooter(text: "Request $90.00 of $100.00 invoice balance over 2 payments.")
                     
                     section += Item(
                         SegmentedControlRow(id: "split-type") { control in

--- a/Demo/Sources/Demos/Demo Screens/ItemInsertAndRemoveAnimationsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ItemInsertAndRemoveAnimationsViewController.swift
@@ -63,7 +63,7 @@ final class ItemInsertAndRemoveAnimationsViewController : ListViewController
         
         list += Section("animations") { section in
             
-            section.header = HeaderFooter(DemoHeader(title: "Item Animations"))
+            section.header = DemoHeader(title: "Item Animations")
             
             for animations in self.animations {
                 

--- a/Demo/Sources/Demos/Demo Screens/ItemizationEditorViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ItemizationEditorViewController.swift
@@ -78,8 +78,8 @@ final class ItemizationEditorViewController : UIViewController
             list += Section(SectionIdentifier.variations) { section in
                 
                 section.layouts.table.columns = .init(count: 2, spacing: 20.0)
-                section.header = HeaderFooter(Header(title: variationsTitle), sizing: .thatFits())
-                section.footer = HeaderFooter(Footer(text: footerText), sizing: .thatFits())
+                section.header = Header(title: variationsTitle)
+                section.footer = Footer(text: footerText)
                 
                 section += self.itemization.variations.all.map { variation in
                     Item(
@@ -99,8 +99,8 @@ final class ItemizationEditorViewController : UIViewController
                     
                     section.layouts.table.columns = .init(count: 2, spacing: 20.0)
                     
-                    section.header = HeaderFooter(Header(title: set.name), sizing: .thatFits())
-                    section.footer = HeaderFooter(Footer(text: "Choose modifiers"), sizing: .thatFits())
+                    section.header = Header(title: set.name)
+                    section.footer = Footer(text: "Choose modifiers")
                     
                     section += set.all.map { modifier in
                         Item(
@@ -119,7 +119,7 @@ final class ItemizationEditorViewController : UIViewController
             list += Section(SectionIdentifier.discounts) { section in
                 
                 section.layouts.table.columns = .init(count: 2, spacing: 20.0)
-                section.header = HeaderFooter(Header(title: "Discounts"), sizing: .thatFits())
+                section.header = Header(title: "Discounts")
                 
                 section += self.availableOptions.allDiscounts.map { discount in
                     ToggleItem(content: .init(title: discount.name, detail: "$0.00", isOn: self.itemization.has(discount))) { isOn in
@@ -135,7 +135,7 @@ final class ItemizationEditorViewController : UIViewController
             list += Section(SectionIdentifier.taxes) { section in
                 
                 section.layouts.table.columns = .init(count: 2, spacing: 20.0)
-                section.header = HeaderFooter(Header(title: "Taxes"), sizing: .thatFits())
+                section.header = Header(title: "Taxes")
                 
                 section += self.availableOptions.allTaxes.map { tax in
                     ToggleItem(content: .init(title: tax.name, detail: "$0.00", isOn: self.itemization.has(tax))) { isOn in

--- a/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
@@ -26,9 +26,7 @@ final class KeyboardTestingViewController : UIViewController
         }
         
         self.listView.configure { list in
-            list.content.overscrollFooter = HeaderFooter(
-                DemoHeader(title: "Thanks for using Listable!!")
-            )
+            list.content.overscrollFooter = DemoHeader(title: "Thanks for using Listable!!")
             
             list += Section("section") { section in
                 section += Item(TextFieldElement(content: "Item 1"), sizing: .fixed(height: 100.0))

--- a/Demo/Sources/Demos/Demo Screens/LocalizedCollationViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/LocalizedCollationViewController.swift
@@ -22,7 +22,7 @@ final class LocalizedCollationViewController : ListViewController {
         }
         
         list += LocalizedItemCollator.sections(with: items) { collated, section in
-            section.header = HeaderFooter(DemoHeader(title: collated.title))
+            section.header = DemoHeader(title: collated.title)
         }
     }
 }

--- a/Demo/Sources/Demos/Demo Screens/PaymentTypesViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/PaymentTypesViewController.swift
@@ -29,7 +29,7 @@ final class PaymentTypesViewController : ListViewController {
         
         list += Section(SectionID.main) { section in
             
-            section.header = HeaderFooter(PaymentTypeHeader(title: SectionID.main.title))
+            section.header = PaymentTypeHeader(title: SectionID.main.title)
             
             section += types.filter { $0.isEnabled }
             .filter { $0.isMain }
@@ -39,7 +39,7 @@ final class PaymentTypesViewController : ListViewController {
         
         list += Section(SectionID.more) { section in
             
-            section.header = HeaderFooter(PaymentTypeHeader(title: SectionID.more.title))
+            section.header = PaymentTypeHeader(title: SectionID.more.title)
             
             section += types.filter { $0.isEnabled }
             .filter { $0.isMain == false }
@@ -49,7 +49,7 @@ final class PaymentTypesViewController : ListViewController {
         
         list += Section(SectionID.disabled) { section in
             
-            section.header = HeaderFooter(PaymentTypeHeader(title: SectionID.disabled.title))
+            section.header = PaymentTypeHeader(title: SectionID.disabled.title)
             
             section.reordering.minItemCount = 0
             

--- a/Demo/Sources/Demos/Demo Screens/ReorderingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ReorderingViewController.swift
@@ -40,7 +40,7 @@ final class ReorderingViewController : ListViewController
         }
         
         list += Section("1") { section in
-            section.header = HeaderFooter(DemoHeader(title: "First Section"))
+            section.header = DemoHeader(title: "First Section")
             
             section.layouts.table.columns = .init(count: 2, spacing: 15.0)
             
@@ -62,7 +62,7 @@ final class ReorderingViewController : ListViewController
         }
         
         list += Section("2") { section in
-            section.header = HeaderFooter(DemoHeader(title: "Second Section"))
+            section.header = DemoHeader(title: "Second Section")
             
             section += Item(DemoItem(text: "1,0  Row")) { item in
                 item.reordering = ItemReordering(sections: .all)
@@ -75,7 +75,7 @@ final class ReorderingViewController : ListViewController
         }
         
         list += Section("3") { section in
-            section.header = HeaderFooter(DemoHeader(title: "Third Section"))
+            section.header = DemoHeader(title: "Third Section")
             
             section += Item(DemoItem(text: "2,0  Row (Can't Move)")) { item in
                 

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -26,15 +26,11 @@ public final class DemosRootViewController : ListViewController
         list.appearance = .demoAppearance
         list.layout = .demoLayout
         
-        list.content.overscrollFooter = HeaderFooter(
-            DemoHeader(title: "Thanks for using Listable!!")
-        )
+        list.content.overscrollFooter = DemoHeader(title: "Thanks for using Listable!!")
         
         list("list-view") { section in
             
-            section.header = HeaderFooter(
-                DemoHeader(title: "List Views")
-            )
+            section.header = DemoHeader(title: "List Views")
             
             section += Item(
                 DemoItem(text: "Basic Demo"),
@@ -177,9 +173,7 @@ public final class DemosRootViewController : ListViewController
         
         list("coordinator") { section in
             
-            section.header = HeaderFooter(
-                DemoHeader(title: "Item Coordinator")
-            )
+            section.header = DemoHeader(title: "Item Coordinator")
             
             section += Item(
                 DemoItem(text: "Expand / Collapse Items"),
@@ -199,9 +193,7 @@ public final class DemosRootViewController : ListViewController
         
         list("layouts") { section in
             
-            section.header = HeaderFooter(
-                DemoHeader(title: "Other Layouts")
-            )
+            section.header = DemoHeader(title: "Other Layouts")
             
             section += Item(
                 DemoItem(text: "Grid Layout"),
@@ -248,9 +240,7 @@ public final class DemosRootViewController : ListViewController
         
         list("selection-state") { section in
             
-            section.header = HeaderFooter(
-                DemoHeader(title: "List View Selection")
-            )
+            section.header = DemoHeader(title: "List View Selection")
 
             section += Item(
                 DemoItem(text: "Tappable Row"),
@@ -268,9 +258,7 @@ public final class DemosRootViewController : ListViewController
         
         list("collection-view") { section in
             
-            section.header = HeaderFooter(
-                DemoHeader(title: "UICollectionViews")
-            )
+            section.header = DemoHeader(title: "UICollectionViews")
 
             section += Item(
                 DemoItem(text: "Flow Layout"),
@@ -282,9 +270,7 @@ public final class DemosRootViewController : ListViewController
         
         list("scroll-view") { section in
             
-            section.header = HeaderFooter(
-                DemoHeader(title: "UIScrollViews")
-            )
+            section.header = DemoHeader(title: "UIScrollViews")
             
             section += Item(
                 DemoItem(text: "Edges Playground"),

--- a/ListableUI/Sources/Content.swift
+++ b/ListableUI/Sources/Content.swift
@@ -22,17 +22,17 @@ public struct Content
     public var refreshControl : RefreshControl?
     
     /// A header provided by the container of the list, eg a nav-style "large header".
-    public var containerHeader : AnyHeaderFooter?
+    public var containerHeader : AnyHeaderFooterConvertible?
     
     /// The header for the list, usually displayed before all other content.
-    public var header : AnyHeaderFooter?
+    public var header : AnyHeaderFooterConvertible?
     
     /// The footer for the list, usually displayed after all other content.
-    public var footer : AnyHeaderFooter?
+    public var footer : AnyHeaderFooterConvertible?
     
     /// The overscroll footer for the list, which is displayed below the bottom bounds of the visible frame,
     /// so it is only visible if the user manually scrolls the list up to make it visible.
-    public var overscrollFooter : AnyHeaderFooter?
+    public var overscrollFooter : AnyHeaderFooterConvertible?
     
     /// All sections in the list.
     public var sections : [Section]
@@ -104,10 +104,10 @@ public struct Content
     public init(
         identifier : AnyHashable? = nil,
         refreshControl : RefreshControl? = nil,
-        containerHeader : AnyHeaderFooter? = nil,
-        header : AnyHeaderFooter? = nil,
-        footer : AnyHeaderFooter? = nil,
-        overscrollFooter : AnyHeaderFooter? = nil,
+        containerHeader : AnyHeaderFooterConvertible? = nil,
+        header : AnyHeaderFooterConvertible? = nil,
+        footer : AnyHeaderFooterConvertible? = nil,
+        overscrollFooter : AnyHeaderFooterConvertible? = nil,
         sections : [Section] = []
     ) {
         self.identifier = identifier

--- a/ListableUI/Sources/HeaderFooter/AnyHeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/AnyHeaderFooter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-public protocol AnyHeaderFooter : AnyHeaderFooter_Internal
+public protocol AnyHeaderFooter : AnyHeaderFooterConvertible, AnyHeaderFooter_Internal
 {
     var anyContent : Any { get }
     

--- a/ListableUI/Sources/HeaderFooter/AnyHeaderFooterConvertible.swift
+++ b/ListableUI/Sources/HeaderFooter/AnyHeaderFooterConvertible.swift
@@ -1,0 +1,41 @@
+//
+//  AnyHeaderFooterConvertible.swift
+//  ListableUI
+//
+//  Created by Kyle Van Essen on 9/28/21.
+//
+
+import Foundation
+
+
+/// A type which can be converted into a `HeaderFooter`, so you
+/// do not need to explicitly wrap / convert your `HeaderFooterContent`
+/// in a `HeaderFooter` when providing an header or footer to a list or section:
+///
+/// ```
+/// Section("id") { section in
+///     section.header = MyHeaderContent(title: "Hello, World!")
+/// }
+///
+/// struct MyHeaderContent : HeaderFooterContent {
+///    var title : String
+///    ...
+/// }
+/// ```
+///
+/// Only two types conform to this protocol:
+///
+/// ### `HeaderFooter`
+/// The `HeaderFooter` conformance simply returns self.
+///
+/// ### `HeaderFooterContent`
+/// The `HeaderFooterContent` conformance returns `HeaderFooter(self)`,
+/// utilizing the default values from the `HeaderFooter` initializer.
+///
+public protocol AnyHeaderFooterConvertible {
+    
+    /// Converts the object into a type-erased `AnyHeaderFooter` instance.
+    func toHeaderFooter() -> AnyHeaderFooter
+}
+
+

--- a/ListableUI/Sources/HeaderFooter/AnyHeaderFooterConvertible.swift
+++ b/ListableUI/Sources/HeaderFooter/AnyHeaderFooterConvertible.swift
@@ -35,7 +35,7 @@ import Foundation
 public protocol AnyHeaderFooterConvertible {
     
     /// Converts the object into a type-erased `AnyHeaderFooter` instance.
-    func toHeaderFooter() -> AnyHeaderFooter
+    func asAnyHeaderFooter() -> AnyHeaderFooter
 }
 
 

--- a/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
@@ -71,7 +71,7 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     
     // MARK: AnyHeaderFooterConvertible
     
-    public func toHeaderFooter() -> AnyHeaderFooter {
+    public func asAnyHeaderFooter() -> AnyHeaderFooter {
         self
     }
     
@@ -124,7 +124,7 @@ extension HeaderFooterContent {
     ///     section.header = MyHeaderContent(
     ///         title: "Hello, World!"
     ///     )
-    ///     .setting(
+    ///     .with(
     ///         sizing: .thatFits(.noConstraint),
     ///     )
     ///
@@ -133,7 +133,7 @@ extension HeaderFooterContent {
     ///    ...
     /// }
     /// ```
-    public func setting(
+    public func with(
         sizing : Sizing? = nil,
         layouts : HeaderFooterLayouts? = nil,
         onTap : HeaderFooter<Self>.OnTap? = nil

--- a/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
@@ -69,6 +69,12 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
         self.content.reappliesToVisibleView
     }
     
+    // MARK: AnyHeaderFooterConvertible
+    
+    public func toHeaderFooter() -> AnyHeaderFooter {
+        self
+    }
+    
     // MARK: AnyHeaderFooter_Internal
     
     public func apply(
@@ -103,6 +109,42 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     public func newPresentationHeaderFooterState(performsContentCallbacks : Bool) -> Any
     {
         return PresentationState.HeaderFooterState(self, performsContentCallbacks: performsContentCallbacks)
+    }
+}
+
+
+extension HeaderFooterContent {
+    
+    /// Identical to `HeaderFooter.init` which takes in a `HeaderFooterContent`,
+    /// except you can call this on the `HeaderFooterContent` itself, instead of wrapping it,
+    /// to avoid additional nesting, and to hoist your content up in your code.
+    ///
+    /// ```
+    /// Section("id") { section in
+    ///     section.header = MyHeaderContent(
+    ///         title: "Hello, World!"
+    ///     )
+    ///     .setting(
+    ///         sizing: .thatFits(.noConstraint),
+    ///     )
+    ///
+    /// struct MyHeaderContent : HeaderFooterContent {
+    ///    var title : String
+    ///    ...
+    /// }
+    /// ```
+    public func setting(
+        sizing : Sizing? = nil,
+        layouts : HeaderFooterLayouts? = nil,
+        onTap : HeaderFooter<Self>.OnTap? = nil
+    ) -> HeaderFooter<Self>
+    {
+        HeaderFooter(
+            self,
+            sizing: sizing,
+            layouts: layouts,
+            onTap: onTap
+        )
     }
 }
 

--- a/ListableUI/Sources/HeaderFooter/HeaderFooterContent.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooterContent.swift
@@ -183,7 +183,7 @@ public extension HeaderFooterContent {
     
     // MARK: AnyHeaderFooterConvertible
     
-    func toHeaderFooter() -> AnyHeaderFooter {
+    func asAnyHeaderFooter() -> AnyHeaderFooter {
         HeaderFooter(self)
     }
 }

--- a/ListableUI/Sources/HeaderFooter/HeaderFooterContent.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooterContent.swift
@@ -42,7 +42,7 @@ public typealias FooterContent = HeaderFooterContent
 /// z-Index 2) `PressedBackgroundView` (Only if the header/footer is pressed, eg if the wrapping `HeaderFooter` has an `onTap` handler.)
 /// z-Index 1) `BackgroundView`
 ///
-public protocol HeaderFooterContent
+public protocol HeaderFooterContent : AnyHeaderFooterConvertible
 {
     //
     // MARK: Tracking Changes
@@ -175,6 +175,16 @@ public extension HeaderFooterContent {
     
     var reappliesToVisibleView: ReappliesToVisibleView {
         .always
+    }
+}
+
+
+public extension HeaderFooterContent {
+    
+    // MARK: AnyHeaderFooterConvertible
+    
+    func toHeaderFooter() -> AnyHeaderFooter {
+        HeaderFooter(self)
     }
 }
 

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
@@ -58,7 +58,7 @@ extension PresentationState
         
         func update(
             with state : AnyPresentationHeaderFooterState?,
-            new: AnyHeaderFooter?,
+            new: AnyHeaderFooterConvertible?,
             reason: ApplyReason,
             updateCallbacks : UpdateCallbacks,
             environment: ListEnvironment
@@ -69,7 +69,7 @@ extension PresentationState
             } else {
                 if let state = state, let new = new {
                     state.set(
-                        new: new,
+                        new: new.toHeaderFooter(),
                         reason: reason,
                         visibleView: self.visibleContainer?.content,
                         updateCallbacks: updateCallbacks,

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
@@ -69,7 +69,7 @@ extension PresentationState
             } else {
                 if let state = state, let new = new {
                     state.set(
-                        new: new.toHeaderFooter(),
+                        new: new.asAnyHeaderFooter(),
                         reason: reason,
                         visibleView: self.visibleContainer?.content,
                         updateCallbacks: updateCallbacks,

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
@@ -130,12 +130,12 @@ extension PresentationState
         }
         
         static func newHeaderFooterState(
-            with new : AnyHeaderFooter?,
+            with new : AnyHeaderFooterConvertible?,
             performsContentCallbacks : Bool
         ) -> AnyPresentationHeaderFooterState?
         {
             if let new = new {
-                return (new.newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
+                return (new.toHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
             } else {
                 return nil
             }
@@ -143,7 +143,7 @@ extension PresentationState
         
         static func headerFooterState(
             current : AnyPresentationHeaderFooterState?,
-            new : AnyHeaderFooter?,
+            new : AnyHeaderFooterConvertible?,
             performsContentCallbacks : Bool
         ) -> AnyPresentationHeaderFooterState?
         {
@@ -154,14 +154,14 @@ extension PresentationState
                     if isSameType {
                         return current
                     } else {
-                        return (new.newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
+                        return (new.toHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
                     }
                 } else {
                     return nil
                 }
             } else {
                 if let new = new {
-                    return (new.newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
+                    return (new.toHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
                 } else {
                     return nil
                 }

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
@@ -135,7 +135,7 @@ extension PresentationState
         ) -> AnyPresentationHeaderFooterState?
         {
             if let new = new {
-                return (new.toHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
+                return (new.asAnyHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
             } else {
                 return nil
             }
@@ -154,14 +154,14 @@ extension PresentationState
                     if isSameType {
                         return current
                     } else {
-                        return (new.toHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
+                        return (new.asAnyHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
                     }
                 } else {
                     return nil
                 }
             } else {
                 if let new = new {
-                    return (new.toHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
+                    return (new.asAnyHeaderFooter().newPresentationHeaderFooterState(performsContentCallbacks: performsContentCallbacks) as! AnyPresentationHeaderFooterState)
                 } else {
                     return nil
                 }

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -177,7 +177,7 @@ extension ItemContent {
     /// ```
     /// Section("id") { section in
     ///     section += MyItemContent(name: "Listable")
-    ///                   .setting(
+    ///                   .with(
     ///                       sizing: .thatFits(.noConstraint),
     ///                       selectionStyle: .tappable
     ///                   )
@@ -187,7 +187,7 @@ extension ItemContent {
     ///    ...
     /// }
     /// ```
-    public func setting(
+    public func with(
         sizing : Sizing? = nil,
         layouts : ItemLayouts? = nil,
         selectionStyle : ItemSelectionStyle? = nil,

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -168,6 +168,65 @@ public struct Item<Content:ItemContent> : AnyItem
 }
 
 
+extension ItemContent {
+    
+    /// Identical to `Item.init` which takes in an `ItemContent`,
+    /// except you can call this on the `ItemContent` itself, instead of wrapping it,
+    /// to avoid additional nesting, and to hoist your content up in your code.
+    ///
+    /// ```
+    /// Section("id") { section in
+    ///     section += MyItemContent(name: "Listable")
+    ///                   .setting(
+    ///                       sizing: .thatFits(.noConstraint),
+    ///                       selectionStyle: .tappable
+    ///                   )
+    ///
+    /// struct MyItemContent : ItemContent {
+    ///    var name : String
+    ///    ...
+    /// }
+    /// ```
+    public func setting(
+        sizing : Sizing? = nil,
+        layouts : ItemLayouts? = nil,
+        selectionStyle : ItemSelectionStyle? = nil,
+        insertAndRemoveAnimations : ItemInsertAndRemoveAnimations? = nil,
+        swipeActions : SwipeActionsConfiguration? = nil,
+        reordering : ItemReordering? = nil,
+        onWasReordered : Item<Self>.OnWasReordered? = nil,
+        onDisplay : Item<Self>.OnDisplay.Callback? = nil,
+        onEndDisplay : Item<Self>.OnEndDisplay.Callback? = nil,
+        onSelect : Item<Self>.OnSelect.Callback? = nil,
+        onDeselect : Item<Self>.OnDeselect.Callback? = nil,
+        onInsert : Item<Self>.OnInsert.Callback? = nil,
+        onRemove : Item<Self>.OnRemove.Callback? = nil,
+        onMove : Item<Self>.OnMove.Callback? = nil,
+        onUpdate : Item<Self>.OnUpdate.Callback? = nil
+    ) -> Item<Self>
+    {
+        Item(
+            self,
+            sizing: sizing,
+            layouts: layouts,
+            selectionStyle: selectionStyle,
+            insertAndRemoveAnimations: insertAndRemoveAnimations,
+            swipeActions: swipeActions,
+            reordering: reordering,
+            onWasReordered: onWasReordered,
+            onDisplay: onDisplay,
+            onEndDisplay: onEndDisplay,
+            onSelect: onSelect,
+            onDeselect: onDeselect,
+            onInsert: onInsert,
+            onRemove: onRemove,
+            onMove: onMove,
+            onUpdate: onUpdate
+        )
+    }
+}
+
+
 extension Item : SignpostLoggable
 {
     var signpostInfo : SignpostLoggingInfo {

--- a/ListableUI/Sources/LocalizedItemCollator.swift
+++ b/ListableUI/Sources/LocalizedItemCollator.swift
@@ -64,8 +64,8 @@ public protocol AnyLocalizedCollatableItem : AnyItem {
 ///         /// You are passed a pre-populated section on which you may
 ///         /// customize the header and footer, or mutate the content.
 ///
-///         section.header = HeaderFooter(DemoHeader(title: collated.title))
-///         section.footer = HeaderFooter(DemoFooter(title: collated.title))
+///         section.header = DemoHeader(title: collated.title)
+///         section.footer = DemoFooter(title: collated.title)
 ///     }
 /// }
 ///
@@ -106,8 +106,8 @@ public struct LocalizedItemCollator {
     /// ```
     /// List { list in
     ///     list += LocalizedItemCollator.sections(with: items) { collated, section in
-    ///         section.header = HeaderFooter(DemoHeader(title: collated.title))
-    ///         section.footer = HeaderFooter(DemoFooter(title: collated.title))
+    ///         section.header = DemoHeader(title: collated.title)
+    ///         section.footer = DemoFooter(title: collated.title)
     ///     }
     /// }
     ///

--- a/ListableUI/Sources/Section/Section.swift
+++ b/ListableUI/Sources/Section/Section.swift
@@ -19,10 +19,10 @@ public struct Section
     public var identifier : Identifier
     
     /// The header, if any, associated with the section.
-    public var header : AnyHeaderFooter?
+    public var header : AnyHeaderFooterConvertible?
     
     /// The footer, if any, associated with the section.
-    public var footer : AnyHeaderFooter?
+    public var footer : AnyHeaderFooterConvertible?
     
     /// The items, if any, associated with the section.
     public var items : [AnyItem]
@@ -79,8 +79,8 @@ public struct Section
     public init<IdentifierValue:Hashable>(
         _ identifier : IdentifierValue,
         layouts : SectionLayouts = .init(),
-        header : AnyHeaderFooter? = nil,
-        footer : AnyHeaderFooter? = nil,
+        header : AnyHeaderFooterConvertible? = nil,
+        footer : AnyHeaderFooterConvertible? = nil,
         reordering : SectionReordering = .init(),
         items : [AnyItem] = [],
         configure : Configure = { _ in }

--- a/ListableUI/Tests/Layout/Paged/PagedListLayoutTests.swift
+++ b/ListableUI/Tests/Layout/Paged/PagedListLayoutTests.swift
@@ -45,13 +45,13 @@ class PagedListLayoutTests : XCTestCase
                 $0.itemInsets = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
             }
             
-            list.content.header = HeaderFooter(TestingHeaderFooterContent(color: .blue))
-            list.content.footer = HeaderFooter(TestingHeaderFooterContent(color: .green))
+            list.content.header = TestingHeaderFooterContent(color: .blue)
+            list.content.footer = TestingHeaderFooterContent(color: .green)
             
             list += Section("first") { section in
                 
-                section.header = HeaderFooter(TestingHeaderFooterContent(color: .purple))
-                section.footer = HeaderFooter(TestingHeaderFooterContent(color: .red))
+                section.header = TestingHeaderFooterContent(color: .purple)
+                section.footer = TestingHeaderFooterContent(color: .red)
                 
                 section += TestingItemContent(color: .init(white: 0.0, alpha: 0.3))
                 section += TestingItemContent(color: .init(white: 0.0, alpha: 0.4))
@@ -60,8 +60,8 @@ class PagedListLayoutTests : XCTestCase
             
             list += Section("second") { section in
                 
-                section.header = HeaderFooter(TestingHeaderFooterContent(color: .purple))
-                section.footer = HeaderFooter(TestingHeaderFooterContent(color: .red))
+                section.header = TestingHeaderFooterContent(color: .purple)
+                section.footer = TestingHeaderFooterContent(color: .red)
                 
                 section += TestingItemContent(color: .init(white: 0.0, alpha: 0.6))
                 section += TestingItemContent(color: .init(white: 0.0, alpha: 0.7))

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -26,13 +26,13 @@ class ListViewTests: XCTestCase
             
             listView?.configure { list in
                 
-                list.content.header = HeaderFooter(TestSupplementary())
-                list.content.footer = HeaderFooter(TestSupplementary())
-                list.content.overscrollFooter = HeaderFooter(TestSupplementary())
+                list.content.header = TestSupplementary()
+                list.content.footer = TestSupplementary()
+                list.content.overscrollFooter = TestSupplementary()
 
                 list("content") { section in
-                    section.header = HeaderFooter(TestSupplementary())
-                    section.footer = HeaderFooter(TestSupplementary())
+                    section.header = TestSupplementary()
+                    section.footer = TestSupplementary()
                     
                     section += TestContent(content: "1")
                     section += TestContent(content: "2")
@@ -65,7 +65,7 @@ class ListViewTests: XCTestCase
             list.animatesChanges = false
             
             list += Section("a-section")
-            list.content.overscrollFooter = HeaderFooter(TestSupplementary())
+            list.content.overscrollFooter = TestSupplementary()
         }
         
         listView.collectionView.contentOffset.y = 100
@@ -85,7 +85,7 @@ class ListViewTests: XCTestCase
             list.animatesChanges = false
             
             list += Section("a-section")
-            list.content.overscrollFooter = HeaderFooter(TestSupplementary())
+            list.content.overscrollFooter = TestSupplementary()
         }
         
         listView.collectionView.contentOffset.y = 100

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Listable is a declarative list framework for iOS, which allows you to concisely 
 self.listView.setContent { list in
     list += Section("section-1") { section in
         
-        section.header = HeaderFooter(with: DemoHeader(title: "This Is A Header"))
+        section.header = DemoHeader(title: "This Is A Header")
         
         section += DemoItem(text: "And here is a row")
         section += DemoItem(text: "And here is another row.")
@@ -25,7 +25,7 @@ self.listView.setContent { list in
 
     list += Section("section-2") { section in
         
-        section.header = HeaderFooter(with: DemoHeader(title: "Another Header"))
+        section.header = DemoHeader(title: "Another Header")
         
         section += DemoItem(text: "The last row.")
     }    
@@ -51,7 +51,7 @@ And then push in new content, so there  is one row with one section:
 ```swift
 self.listView.setContent { list in
     list += Section("section-1") { section in
-        section.header = HeaderFooter(with: DemoHeader(title: "This Is A Header"))
+        section.header = DemoHeader(title: "This Is A Header")
         
         section += DemoItem(text: "And here is a row")
     } 
@@ -63,7 +63,7 @@ This new section will be animated into place. If you then insert another row:
 ```swift
 self.listView.setContent { list in
     list += Section("section-1") { section in
-        section.header = HeaderFooter(with: DemoHeader(title: "This Is A Header"))
+        section.header = DemoHeader(title: "This Is A Header")
         
         section += DemoItem(text: "And here is a row")
         section += DemoItem(text: "Another row!")
@@ -465,8 +465,8 @@ You set headers and footers on sections via the `header` and `footer` parameter.
 ```swift
 self.listView.configure { list in
     list += Section("section-1") { section in
-        section.header = HeaderFooter(DemoHeader(title: "This Is A Header"))
-        section.footer = HeaderFooter(DemoFooter(text: "And this is a footer. Please check the EULA for details."))
+        section.header = DemoHeader(title: "This Is A Header")
+        section.footer = DemoFooter(text: "And this is a footer. Please check the EULA for details.")
     } 
 }
 ```


### PR DESCRIPTION
### AnyHeaderFooterConvertible

This is now the type used in public APIs in place of `AnyHeaderFooter`:

```
public protocol AnyHeaderFooterConvertible {
    
    /// Converts the object into a type-erased `AnyHeaderFooter` instance.
    func toHeaderFooter() -> AnyHeaderFooter
}
```

This means that you can now do:

```swift
section.header = MyHeaderContent(title: "Albums")
```

Instead of:

```swift
section.header = HeaderFooter(MyHeaderContent(title: "Albums"))
```

In the vast majority of cases.

I've converted all the usages in tests and the demo app.

### Updated Demo Styling
Updated the demo app styling to more closely match the iOS 15 grouped table view.

### `.setting(...` functions
This introduces builder-style syntax for wrapping `ItemContent` and `HeaderFooterContent` in an `Item` and `HeaderFooter`. I don't love this name right now – looking for suggestions!