### PR TITLE
Allow clients to specify a `swipeActionStyle`  to customize a swipe actions view style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 ### Added
+- [Introduced `swipeActionsStyle` property in `ItemContent` protocol](https://github.com/kyleve/Listable/pull/335). This allows clients to configure and specify different visual styles for swipe action views (such as `rounded` swipe actions).  
 
 ### Removed
 

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -16,7 +16,7 @@ final class SwipeActionsViewController: UIViewController  {
 
     private var allowDeleting: Bool = true
 
-    private var items = (0..<20).map { SwipeActionItem(isSaved: Bool.random(), identifier: $0) }
+    private var items = (0..<10).map { SwipeActionItem(isSaved: Bool.random(), identifier: $0) }
 
     override func loadView() {
         self.title = "Swipe Actions"
@@ -52,10 +52,29 @@ final class SwipeActionsViewController: UIViewController  {
                 }
             }
 
-            list += Section("items") { section in
+            list += Section("standardSwipeActionItems") { section in
+                section.header = DemoHeader(title: "Standard Style Swipable Items")
                 section += self.items.map { item in
                     Item(
-                        SwipeActionsDemoItem(item: item),
+                        SwipeActionsDemoItem(item: item, swipeActionsStyle: .default),
+                        swipeActions: self.makeSwipeActions(for: item)
+                    )
+                }
+            }
+
+            list += Section("customSwipeActionItems") { section in
+                section.header = DemoHeader(title: "Custom Style Swipable Items")
+                section += self.items.map { item in
+                    Item(
+                        SwipeActionsDemoItem(
+                            item: item,
+                            swipeActionsStyle:
+                                .init(
+                                    actionShape: .rectangle(cornerRadius: 8),
+                                    interActionSpacing: 8,
+                                    containerInsets: .init(top: 8, left: 8, bottom: 8, right: 8)
+                                )
+                        ),
                         swipeActions: self.makeSwipeActions(for: item)
                     )
                 }
@@ -128,6 +147,7 @@ final class SwipeActionsViewController: UIViewController  {
 
     struct SwipeActionsDemoItem: BlueprintItemContent, Equatable {
         var item: SwipeActionItem
+        var swipeActionsStyle: DefaultSwipeActionsView.Style
 
         var identifierValue: Int {
             self.item.identifier

--- a/ListableUI/Sources/Internal/DefaultSwipeView.swift
+++ b/ListableUI/Sources/Internal/DefaultSwipeView.swift
@@ -11,11 +11,47 @@ private let haptics = UIImpactFeedbackGenerator(style: .light)
 
 public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView {
 
+    public struct Style: Equatable {
+        public enum Shape: Equatable {
+            case rectangle(cornerRadius: CGFloat)
+        }
+
+        public static let `default` = Style()
+
+        public var actionShape: Shape
+        public var interActionSpacing: CGFloat
+        public var containerInsets: UIEdgeInsets
+
+        public init(
+            actionShape: Shape = .rectangle(cornerRadius: 0),
+            interActionSpacing: CGFloat = 0,
+            containerInsets: UIEdgeInsets = .zero
+        ) {
+            self.actionShape = actionShape
+            self.interActionSpacing = interActionSpacing
+            self.containerInsets = containerInsets
+        }
+
+        var cornerRadius: CGFloat {
+            switch actionShape {
+            case .rectangle(let cornerRadius):
+                return cornerRadius
+            }
+        }
+    }
+
     private var actionButtons: [DefaultSwipeActionButton] = []
+    private let container: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.clipsToBounds = true
+        return view
+    }()
     private var calculatedNaturalWidth: CGFloat = 0
 
     private var firstAction: SwipeAction?
     private var didPerformAction: SwipeAction.CompletionHandler
+    private let style: Style
 
     public var swipeActionsWidth: CGFloat {
         calculatedNaturalWidth + safeAreaInsets.right
@@ -23,10 +59,16 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
 
     private var state: SwipeActionState = .closed
 
-    public init(didPerformAction: @escaping SwipeAction.CompletionHandler) {
+    public init(
+        style: Style,
+        didPerformAction: @escaping SwipeAction.CompletionHandler
+    ) {
+        self.style = style
         self.didPerformAction = didPerformAction
         super.init(frame: .zero)
         clipsToBounds = true
+
+        addSubview(container)
     }
 
     required init?(coder: NSCoder) {
@@ -35,6 +77,12 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
 
     public override func layoutSubviews() {
         super.layoutSubviews()
+
+        let insets = style.containerInsets
+        container.frame.origin.y = insets.top
+        container.frame.origin.x = insets.left
+        container.frame.size.width = max(0, bounds.size.width - insets.left - insets.right)
+        container.frame.size.height = max(0, bounds.size.height - insets.top - insets.bottom)
 
         // Calculates the x origin for each button based on the width of each button before it
         // and the percent that the actions are slid open for the overlapping parallax effect
@@ -48,15 +96,15 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
         for (index, button) in actionButtons.enumerated() {
             // Size each button to its natural size, but always match the height
             button.sizeToFit()
-            button.frame.size.height = bounds.height
+            button.frame.size.height = container.bounds.height
 
             // Each button is wrapped in a container that enables the parallax effect.
             // They're positioned using the function above, and the width is based on
             // the space available before the next button.
             let wrapperView = button.superview!
             wrapperView.frame = button.frame
-            wrapperView.frame.origin.x = xOriginForButton(at: index)
-            wrapperView.frame.size.width = xOriginForButton(at: index + 1) - xOriginForButton(at: index)
+            wrapperView.frame.origin.x = xOriginForButton(at: index) + CGFloat(index) * style.interActionSpacing
+            wrapperView.frame.size.width = max(0, xOriginForButton(at: index + 1) - xOriginForButton(at: index))
 
             // If there's only one action, the button stays right-aligned while the container stretches.
             // For multiple actions, they stay left-aligned.
@@ -69,13 +117,13 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
 
         // Adjust the last button container view to fill the safe area space
         if let lastButtonContainer = actionButtons.last?.superview {
-            lastButtonContainer.frame.size.width = bounds.width - lastButtonContainer.frame.origin.x
+            lastButtonContainer.frame.size.width = max(0, container.bounds.width - lastButtonContainer.frame.origin.x)
         }
 
         // If the last action will be automatically performed or the state is set to expand the actions
         // for performing the last action, have the last action fill the available space.
         if state == .swiping(willPerformAction: true) || state == .expandActions {
-            actionButtons.last?.superview?.frame = bounds
+            actionButtons.last?.superview?.frame = container.bounds
             actionButtons.last?.frame.origin.x = 0
         }
     }
@@ -83,7 +131,7 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
     private func width(ofButtons buttons: [DefaultSwipeActionButton]) -> CGFloat {
         buttons.reduce(0) { width, button in
             width + button.sizeThatFits(UIView.layoutFittingCompressedSize).width
-        }
+        } + CGFloat(max(0, buttons.count - 1)) * style.interActionSpacing
     }
 
     public func apply(actions: SwipeActionsConfiguration) {
@@ -91,9 +139,11 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
             actionButtons.forEach { $0.superview?.removeFromSuperview() }
             actionButtons = actions.actions.map { _ in
                 let button = DefaultSwipeActionButton()
+                button.layer.cornerRadius = style.cornerRadius
                 let wrapperView = UIView()
                 wrapperView.addSubview(button)
-                addSubview(wrapperView)
+                wrapperView.layer.cornerRadius = style.cornerRadius
+                container.addSubview(wrapperView)
                 return button
             }
         }
@@ -105,7 +155,7 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
             actionButtons[index].superview?.backgroundColor = action.backgroundColor
         }
 
-        calculatedNaturalWidth = width(ofButtons: actionButtons)
+        calculatedNaturalWidth = width(ofButtons: actionButtons) + style.containerInsets.left + style.containerInsets.right
     }
 
     public func apply(state: SwipeActionState) {

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -99,10 +99,10 @@ extension ItemCell {
             setNeedsLayout()
         }
 
-        public func registerSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, reason: ApplyReason) {
+        public func registerSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, style: Content.SwipeActionsView.Style, reason: ApplyReason) {
             if swipeConfiguration == nil {
 
-                let swipeView = Content.SwipeActionsView(didPerformAction: self.didPerformAction)
+                let swipeView = Content.SwipeActionsView(style: style, didPerformAction: self.didPerformAction)
 
                 insertSubview(swipeView, belowSubview: contentView)
                 swipeView.clipsToBounds = true

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
@@ -294,7 +294,7 @@ extension PresentationState
                         
             // Apply Swipe To Action Appearance
             if let actions = self.model.swipeActions {
-                cell.contentContainer.registerSwipeActionsIfNeeded(actions: actions, reason: reason)
+                cell.contentContainer.registerSwipeActionsIfNeeded(actions: actions, style: model.content.swipeActionsStyle, reason: reason)
             } else {
                 cell.contentContainer.deregisterSwipeIfNeeded()
             }

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -353,7 +353,10 @@ public protocol ItemContent where Coordinator.ItemContentType == Self
     /// The view type to use to render swipe actions (delete, etc) for this content.
     /// A default implementation, which matches `UITableView`, is provided.
     associatedtype SwipeActionsView: ItemContentSwipeActionsView = DefaultSwipeActionsView
-    
+
+    /// Specify a swipe action style for this content.
+    var swipeActionsStyle: SwipeActionsView.Style { get }
+
     //
     // MARK: Creating & Providing Content Views
     //
@@ -437,7 +440,6 @@ public protocol ItemContent where Coordinator.ItemContentType == Self
     func makeCoordinator(actions : CoordinatorActions, info : CoordinatorInfo) -> Coordinator
 }
 
-
 /// The views owned by the item content, passed to the `apply(to:) method to theme and provide content.`
 public struct ItemContentViews<Content:ItemContent>
 {
@@ -481,6 +483,11 @@ public struct ApplyItemContentInfo
     public var environment : ListEnvironment
 }
 
+public extension ItemContent where SwipeActionsView.Style == DefaultSwipeActionsView.Style {
+    var swipeActionsStyle: SwipeActionsView.Style {
+        return .default
+    }
+}
 
 public extension ItemContent where Self:Equatable
 {
@@ -599,10 +606,12 @@ public extension ItemContent where BackgroundView == UIView
 /// If you do so, you're completely responsible for creating and laying out the actions,
 /// as well as updating the layout based on the swipe state.
 public protocol ItemContentSwipeActionsView: UIView {
+    /// Swipe action styles (e.g. `standard`, `grouped`, etc.) that are supported by the view.
+    associatedtype Style: Equatable
 
     var swipeActionsWidth: CGFloat { get }
 
-    init(didPerformAction: @escaping SwipeAction.CompletionHandler)
+    init(style: Style, didPerformAction: @escaping SwipeAction.CompletionHandler)
 
     func apply(actions: SwipeActionsConfiguration)
 


### PR DESCRIPTION
**Summary:**
Add a new property `swipeActionStyle` that allows clients to specify a style of swipe actions view (such as `standard` or `custom`). 

**Snapshot:**
![swipe](https://user-images.githubusercontent.com/2122666/136104694-b080ac7b-a36f-410f-bce7-07a64f7411a9.gif)
