### PR TITLE
Revert "Fix keyboard inset"

### DIFF
--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -319,7 +319,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
                     return 0.0
                     
                 case .overlapping(let frame):
-                    return (self.bounds.size.height - frame.origin.y) - self.collectionView.adjustedContentInset.bottom
+                    return (self.bounds.size.height - frame.origin.y) - self.safeAreaInsets.bottom
                 }
             }
         }()


### PR DESCRIPTION
Reverts kyleve/Listable#347

We've seen that this causes larger issues with keyboard inset calculation, so reverting out for now.