### PR TITLE
Fixing bad initialization of TableAppearance.ItemLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- `TableAppearance.ItemLayout` now properly initializes the `itemToSectionFooterSpacing` value.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Layout/Table/TableListLayout.swift
+++ b/ListableUI/Sources/Layout/Table/TableListLayout.swift
@@ -185,7 +185,7 @@ extension TableAppearance
             width : CustomWidth = .default
         ) {
             self.itemSpacing = itemSpacing
-            self.itemSpacing = itemSpacing
+            self.itemToSectionFooterSpacing = itemToSectionFooterSpacing
             
             self.width = width
         }


### PR DESCRIPTION
Fixing a bug where itemSpacing is initialize twice, but itemToSectionFooterSpacing is uninitialized in TableAppearance.ItemLayout