### PR TITLE
Layout Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- `LayoutDescription` now conforms to `Equatable`.
+
 ### Removed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 
 - `LayoutDescription` now conforms to `Equatable`.
+- `ListLayoutAppearance` now has a `func` to modify the default layout.
+- You can now construct a layout description from a `ListLayoutAppearance`, allowing the underlying `ListLayout` to remain internal to a module.
 
 ### Removed
 

--- a/ListableUI/Sources/Layout/Flow/FlowListLayout.swift
+++ b/ListableUI/Sources/Layout/Flow/FlowListLayout.swift
@@ -124,6 +124,10 @@ public struct FlowAppearance : ListLayoutAppearance {
         )
     }
     
+    public func toLayoutDescription() -> LayoutDescription {
+        LayoutDescription(layoutType: FlowListLayout.self, appearance: self)
+    }
+    
     // MARK: Properties
     
     /// How to align the items in a row when they do not take up the full amount of available space.

--- a/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
+++ b/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
@@ -39,7 +39,7 @@ import Foundation
 /// Under the hood, Listable is smart, and will only re-create the underlying
 /// layout object when needed (when the layout type or layout appearance changes).
 ///
-public struct LayoutDescription
+public struct LayoutDescription : Equatable
 {
     let configuration : AnyLayoutDescriptionConfiguration
     
@@ -64,6 +64,10 @@ public struct LayoutDescription
     public var layoutAppearanceProperties : ListLayoutAppearanceProperties {
         configuration.layoutAppearanceProperties()
     }
+    
+    public static func == (lhs : Self, rhs : Self) -> Bool {
+        lhs.configuration.isEqual(to: rhs.configuration)
+    }
 }
 
 
@@ -84,11 +88,15 @@ extension ListLayout
 
 extension LayoutDescription
 {
-    public struct Configuration<LayoutType:ListLayout> : AnyLayoutDescriptionConfiguration
+    public struct Configuration<LayoutType:ListLayout> : AnyLayoutDescriptionConfiguration, Equatable
     {
         public let layoutType : LayoutType.Type
         
         public let layoutAppearance : LayoutType.LayoutAppearance
+        
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.layoutType == rhs.layoutType && lhs.layoutAppearance == rhs.layoutAppearance
+        }
         
         // MARK: AnyLayoutDescriptionConfiguration
         
@@ -141,6 +149,10 @@ extension LayoutDescription
             
             return self.layoutType == other.layoutType
         }
+        
+        public func isEqual(to other : AnyLayoutDescriptionConfiguration) -> Bool {
+            self == (other as? Self)
+        }
     }
 }
 
@@ -163,4 +175,6 @@ public protocol AnyLayoutDescriptionConfiguration
     func shouldRebuild(layout anyLayout : AnyListLayout) -> Bool
 
     func isSameLayoutType(as other : AnyLayoutDescriptionConfiguration) -> Bool
+    
+    func isEqual(to other : AnyLayoutDescriptionConfiguration) -> Bool
 }

--- a/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
+++ b/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
@@ -48,12 +48,20 @@ public struct LayoutDescription : Equatable
         layoutType : LayoutType.Type,
         appearance configure : (inout LayoutType.LayoutAppearance) -> () = { _ in }
     ) {
-        var layoutAppearance = LayoutType.LayoutAppearance.default
-        configure(&layoutAppearance)
+        var appearance = LayoutType.LayoutAppearance.default
+        configure(&appearance)
         
+        self.init(layoutType: layoutType, appearance: appearance)
+    }
+    
+    /// Creates a new layout description for the provided layout type, with the provided appearance.
+    public init<LayoutType:ListLayout>(
+        layoutType : LayoutType.Type,
+        appearance : LayoutType.LayoutAppearance
+    ) {
         self.configuration = Configuration(
             layoutType: layoutType,
-            layoutAppearance: layoutAppearance
+            layoutAppearance: appearance
         )
     }
     

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutAppearance.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutAppearance.swift
@@ -12,6 +12,8 @@ public protocol ListLayoutAppearance : Equatable
 {
     static var `default` : Self { get }
     
+    static func `default`(_ modifying : (inout Self) -> ()) -> Self
+    
     var direction : LayoutDirection { get }
     
     var bounds : ListContentBounds? { get }
@@ -23,6 +25,16 @@ public protocol ListLayoutAppearance : Equatable
     var scrollViewProperties : ListLayoutScrollViewProperties { get }
     
     func toLayoutDescription() -> LayoutDescription
+}
+
+
+extension ListLayoutAppearance {
+    
+    public static func `default`(_ modifying : (inout Self) -> ()) -> Self {
+        var appearance = Self.default
+        modifying(&appearance)
+        return appearance
+    }
 }
 
 

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutAppearance.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutAppearance.swift
@@ -21,6 +21,8 @@ public protocol ListLayoutAppearance : Equatable
     var pagingBehavior : ListPagingBehavior { get }
     
     var scrollViewProperties : ListLayoutScrollViewProperties { get }
+    
+    func toLayoutDescription() -> LayoutDescription
 }
 
 

--- a/ListableUI/Sources/Layout/Paged/PagedListLayout.swift
+++ b/ListableUI/Sources/Layout/Paged/PagedListLayout.swift
@@ -79,6 +79,10 @@ public struct PagedAppearance : ListLayoutAppearance
     
     public let bounds: ListContentBounds? = nil
     
+    public func toLayoutDescription() -> LayoutDescription {
+        LayoutDescription(layoutType: PagedListLayout.self, appearance: self)
+    }
+    
     // MARK: Properties
     
     /// If scroll indicators should be visible along the scrollable axis.

--- a/ListableUI/Sources/Layout/Retail Grid/RetailGridListLayout.swift
+++ b/ListableUI/Sources/Layout/Retail Grid/RetailGridListLayout.swift
@@ -47,6 +47,10 @@ public struct RetailGridAppearance : ListLayoutAppearance
     
     public let bounds: ListContentBounds? = nil
     
+    public func toLayoutDescription() -> LayoutDescription {
+        LayoutDescription(layoutType: RetailGridListLayout.self, appearance: self)
+    }
+    
     // MARK: Properties
     
     public var layout : Layout

--- a/ListableUI/Sources/Layout/Table/TableListLayout.swift
+++ b/ListableUI/Sources/Layout/Table/TableListLayout.swift
@@ -127,6 +127,10 @@ public struct TableAppearance : ListLayoutAppearance
         )
     }
     
+    public func toLayoutDescription() -> LayoutDescription {
+        LayoutDescription(layoutType: TableListLayout.self, appearance: self)
+    }
+    
     // MARK: Properties
     
     /// When providing the `ItemPosition` for items in a list, specifies the max spacing

--- a/ListableUI/Tests/Layout/ListLayout/LayoutDescriptionTests.swift
+++ b/ListableUI/Tests/Layout/ListLayout/LayoutDescriptionTests.swift
@@ -91,6 +91,25 @@ final class LayoutDescriptionTests : XCTestCase
         XCTAssertEqual(description1.configuration.isSameLayoutType(as: description1.configuration), true)
         XCTAssertEqual(description1.configuration.isSameLayoutType(as: description2.configuration), false)
     }
+    
+    func test_equatable() {
+        let description1 = TableListLayout.describe()
+        
+        let description2 = PagedListLayout.describe {
+            $0.direction = .vertical
+        }
+        
+        let description3 = PagedListLayout.describe {
+            $0.direction = .horizontal
+        }
+        
+        XCTAssertEqual(description1 == description1, true)
+        XCTAssertEqual(description2 == description2, true)
+        
+        XCTAssertEqual(description1 == description2, false)
+        
+        XCTAssertEqual(description2 == description3, false)
+    }
 }
 
 

--- a/ListableUI/Tests/Layout/ListLayout/LayoutDescriptionTests.swift
+++ b/ListableUI/Tests/Layout/ListLayout/LayoutDescriptionTests.swift
@@ -138,6 +138,10 @@ private struct TestLayoutAppearance : ListLayoutAppearance
         nil
     }
     
+    func toLayoutDescription() -> LayoutDescription {
+        LayoutDescription(layoutType: TestLayout.self, appearance: self)
+    }
+    
     var anotherValue : String
 }
 


### PR DESCRIPTION
- `LayoutDescription` now conforms to Equatable
- `ListLayoutAppearance` now has a `func` to modify the `default` layout.
- You can now construct a layout description from a `ListLayoutAppearance`.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
