### PR TITLE
A swipe actions memory leak has been fixed for ItemCell.ContentContainerView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - `TableAppearance.ItemLayout` now properly initializes the `itemToSectionFooterSpacing` value.
+- A swipe actions memory leak has been fixed for `ItemCell.ContentContainerView`.
 
 ### Added
 

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -102,7 +102,12 @@ extension ItemCell {
         public func registerSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, style: Content.SwipeActionsView.Style, reason: ApplyReason) {
             if swipeConfiguration == nil {
 
-                let swipeView = Content.SwipeActionsView(style: style, didPerformAction: self.didPerformAction)
+                let swipeView = Content.SwipeActionsView(
+                    style: style,
+                    didPerformAction: { [weak self] expandActions in
+                        self?.didPerformAction(expandActions: expandActions)
+                    }
+                )
 
                 insertSubview(swipeView, belowSubview: contentView)
                 swipeView.clipsToBounds = true


### PR DESCRIPTION
During a memory leaks investigation we found that there is a leak in `ItemCell.ContentContainerView`. 

In `registerSwipeActionsIfNeeded` function, we create a `Content.SwipeActionsView` instance and pass a `self.didPerformAction` function that captures `self`. And since the `Content.SwipeActionsView` instance is added to `self` as a subview, we have a retain cycle.

The changes here break the cycle.
