### PR TITLE
Reordering items with long press support

### DIFF
--- a/BlueprintUILists/Sources/ListReorderGesture.swift
+++ b/BlueprintUILists/Sources/ListReorderGesture.swift
@@ -38,14 +38,19 @@ import UIKit
 /// ```
 public struct ListReorderGesture : Element
 {
+    public enum Begins {
+        case onTap
+        case onLongPress
+    }
+
     /// The element which is being wrapped by the reorder gesture.
     public var element : Element
     
     /// If the gesture is enabled or not.
     public var isEnabled : Bool
 
-    /// TODO
-    public var requiresLongPress: Bool
+    /// Condition to start the reorder gesture
+    public var begins: Begins
     
     let actions : ReorderingActions
     
@@ -56,14 +61,14 @@ public struct ListReorderGesture : Element
     public init(
         isEnabled : Bool = true,
         actions : ReorderingActions,
-        requiresLongPress: Bool = false,
+        begins: Begins = .onTap,
         wrapping element : Element
     ) {
         self.isEnabled =  isEnabled
         
         self.actions = actions
 
-        self.requiresLongPress = requiresLongPress
+        self.begins = begins
         
         self.element = element
     }
@@ -88,7 +93,7 @@ public struct ListReorderGesture : Element
                 
                 view.recognizer.apply(actions: self.actions)
                 
-                view.recognizer.minimumPressDuration = requiresLongPress ? 0.5 : 0.0
+                view.recognizer.minimumPressDuration = begins == .onLongPress ? 0.5 : 0.0
             }
         }
     }
@@ -98,9 +103,12 @@ public struct ListReorderGesture : Element
 public extension Element
 {
     /// Wraps the element in a re-order gesture.
-    func listReorderGesture(with actions : ReorderingActions, isEnabled : Bool = true, requiresLongPress: Bool = false) -> Element
-    {
-        ListReorderGesture(isEnabled: isEnabled, actions: actions, requiresLongPress: requiresLongPress, wrapping: self)
+    func listReorderGesture(
+        with actions : ReorderingActions,
+        isEnabled : Bool = true,
+        begins: ListReorderGesture.Begins = .onTap
+    ) -> Element {
+        ListReorderGesture(isEnabled: isEnabled, actions: actions, begins: begins, wrapping: self)
     }
 }
 

--- a/BlueprintUILists/Sources/ListReorderGesture.swift
+++ b/BlueprintUILists/Sources/ListReorderGesture.swift
@@ -43,6 +43,9 @@ public struct ListReorderGesture : Element
     
     /// If the gesture is enabled or not.
     public var isEnabled : Bool
+
+    /// TODO
+    public var requiresLongPress: Bool
     
     let actions : ReorderingActions
     
@@ -53,11 +56,14 @@ public struct ListReorderGesture : Element
     public init(
         isEnabled : Bool = true,
         actions : ReorderingActions,
+        requiresLongPress: Bool = false,
         wrapping element : Element
     ) {
         self.isEnabled =  isEnabled
         
         self.actions = actions
+
+        self.requiresLongPress = requiresLongPress
         
         self.element = element
     }
@@ -81,6 +87,8 @@ public struct ListReorderGesture : Element
                 view.recognizer.isEnabled = self.isEnabled
                 
                 view.recognizer.apply(actions: self.actions)
+                
+                view.recognizer.minimumPressDuration = requiresLongPress ? 0.5 : 0.0
             }
         }
     }
@@ -90,9 +98,9 @@ public struct ListReorderGesture : Element
 public extension Element
 {
     /// Wraps the element in a re-order gesture.
-    func listReorderGesture(with actions : ReorderingActions, isEnabled : Bool = true) -> Element
+    func listReorderGesture(with actions : ReorderingActions, isEnabled : Bool = true, requiresLongPress: Bool = false) -> Element
     {
-        ListReorderGesture(isEnabled: isEnabled, actions: actions, wrapping: self)
+        ListReorderGesture(isEnabled: isEnabled, actions: actions, requiresLongPress: requiresLongPress, wrapping: self)
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `ListReorderGesture.Begins` added. This controls when the reorder gesture starts: `onTap` and `onLongPress`.
+
 ### Removed
 
 ### Changed

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -132,9 +132,15 @@ struct DemoHeader2 : BlueprintHeaderFooterContent, Equatable
 struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemContent
 {
     var text : String
+    var dragging = false
+    var requiresLongPress = false
     
     var identifierValue: String {
         return self.text
+    }
+    
+    func isEquivalent(to other: DemoItem) -> Bool {
+        text == other.text && other.dragging != other.dragging
     }
 
     typealias SwipeActionsView = DefaultSwipeActionsView
@@ -157,7 +163,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
                         image: UIImage(named: "ReorderControl"),
                         contentMode: .center
                     )
-                        .listReorderGesture(with: info.reorderingActions)
+                        .listReorderGesture(with: info.reorderingActions, requiresLongPress: requiresLongPress)
                 )
             }
         }
@@ -168,7 +174,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
     func backgroundElement(with info: ApplyItemContentInfo) -> Element?
     {
         Box(
-            backgroundColor: .white,
+            backgroundColor: dragging ? .white(0.8) : .white,
             cornerStyle: .rounded(radius: 8.0)
         )
     }

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -132,15 +132,10 @@ struct DemoHeader2 : BlueprintHeaderFooterContent, Equatable
 struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemContent
 {
     var text : String
-    var dragging = false
     var requiresLongPress = false
     
     var identifierValue: String {
         return self.text
-    }
-    
-    func isEquivalent(to other: DemoItem) -> Bool {
-        text == other.text && other.dragging != other.dragging
     }
 
     typealias SwipeActionsView = DefaultSwipeActionsView
@@ -163,7 +158,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
                         image: UIImage(named: "ReorderControl"),
                         contentMode: .center
                     )
-                        .listReorderGesture(with: info.reorderingActions, requiresLongPress: requiresLongPress)
+                        .listReorderGesture(with: info.reorderingActions, begins: requiresLongPress ? .onLongPress : .onTap)
                 )
             }
         }
@@ -174,7 +169,7 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
     func backgroundElement(with info: ApplyItemContentInfo) -> Element?
     {
         Box(
-            backgroundColor: dragging ? .white(0.8) : .white,
+            backgroundColor: info.state.isReordering ? .white(0.8) : .white,
             cornerStyle: .rounded(radius: 8.0)
         )
     }

--- a/Demo/Sources/Demos/Demo Screens/ReorderingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ReorderingViewController.swift
@@ -16,14 +16,10 @@ import BlueprintUICommonControls
 
 final class ReorderingViewController : ListViewController
 {
-    fileprivate var reorderingStorage: ReorderingStorage!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reload", style: .plain, target: self, action: #selector(reload))
-        
-        reorderingStorage = .init()
     }
     
     @objc private func reload() {
@@ -35,15 +31,12 @@ final class ReorderingViewController : ListViewController
         list.appearance = .demoAppearance
         list.layout = .demoLayout
         
-        list.stateObserver.onItemReordered { [weak self] reordered in
+        list.stateObserver.onItemReordered { reordered in
             print("Moved: \(reordered.result.indexPathsDescription)")
             
             reordered.result.toSection.filtered(to: DemoItem.self) { items in
                 print(items.map(\.text).joined(separator: "\n"))
             }
-            
-            self?.reorderingStorage.reset()
-            self?.reload()
         }
         
         list += Section("1") { section in
@@ -103,48 +96,17 @@ final class ReorderingViewController : ListViewController
         list += Section("4") { section in
             section.header = DemoHeader(title: "Long press")
             
-            reorderingStorage.rows.forEach {
-                section += Item($0) { item in
-                    item.reordering = ItemReordering(sections: .current)
-                    item.onStartReorder = { [weak self] item in
-                        self?.reorderingStorage.setDragging(item.identifier.value, dragging: true)
-                        DispatchQueue.main.async {
-                            self?.reload()
-                        }
-                    }
-                }
+            section += Item(DemoItem(text: "3,0 Row (long press)", requiresLongPress: true)) { item in
+                item.reordering = ItemReordering(sections: .current)
             }
-        }
-    }
-}
 
-private final class ReorderingStorage {
-    
-    var rows: [DemoItem] {
-        allRows.values.sorted {
-            $0.identifierValue < $1.identifierValue
-        }
-    }
+            section += Item(DemoItem(text: "3,1 Row (long press)", requiresLongPress: true)) { item in
+                item.reordering = ItemReordering(sections: .current)
+            }
 
-    private var allRows : [String: DemoItem] = {
-        [
-            "Row 1": DemoItem(text: "Row 1", requiresLongPress: true),
-            "Row 2": DemoItem(text: "Row 2", requiresLongPress: true),
-            "Row 3": DemoItem(text: "Row 3", requiresLongPress: true)
-        ]
-    }()
-
-    func setDragging(_ id: String, dragging: Bool) {
-        var row = allRows[id]
-        row?.dragging = dragging
-        if let row = row {
-            allRows[id] = row
-        }
-    }
-
-    func reset() {
-        allRows.forEach { (key, _) in
-            setDragging(key, dragging: false)
+            section += Item(DemoItem(text: "3,2 Row (long press)", requiresLongPress: true)) { item in
+                item.reordering = ItemReordering(sections: .current)
+            }
         }
     }
 }

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
@@ -507,7 +507,11 @@ extension PresentationState
             if self.isReordering {
                 return
             }
-            
+
+            if let callback = self.model.onStartReorder {
+                callback(self.model)
+            }
+
             self.activeReorderEventInfo = .init(
                 originalIndexPath: originalIndexPath
             )

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
@@ -508,10 +508,6 @@ extension PresentationState
                 return
             }
 
-            if let callback = self.model.onStartReorder {
-                callback(self.model)
-            }
-
             self.activeReorderEventInfo = .init(
                 originalIndexPath: originalIndexPath
             )

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -34,11 +34,9 @@ public struct Item<Content:ItemContent> : AnyItem, AnyItemConvertible
     
     public var swipeActions : SwipeActionsConfiguration?
 
-    public typealias OnStartReorder = (Self) -> ()
     public typealias OnWasReordered = (Self, ItemReordering.Result) -> ()
     
     public var reordering : ItemReordering?
-    public var onStartReorder : OnStartReorder?
     public var onWasReordered : OnWasReordered?
         
     public var onDisplay : OnDisplay.Callback?

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -34,9 +34,11 @@ public struct Item<Content:ItemContent> : AnyItem, AnyItemConvertible
     
     public var swipeActions : SwipeActionsConfiguration?
 
+    public typealias OnStartReorder = (Self) -> ()
     public typealias OnWasReordered = (Self, ItemReordering.Result) -> ()
     
     public var reordering : ItemReordering?
+    public var onStartReorder : OnStartReorder?
     public var onWasReordered : OnWasReordered?
         
     public var onDisplay : OnDisplay.Callback?

--- a/ListableUI/Sources/Item/ItemReordering.swift
+++ b/ListableUI/Sources/Item/ItemReordering.swift
@@ -151,7 +151,7 @@ extension ItemReordering {
     ///     }
     /// }
     /// ```
-    public class GestureRecognizer : UILongPressGestureRecognizer, UIGestureRecognizerDelegate
+    public class GestureRecognizer : UILongPressGestureRecognizer
     {
         private typealias OnStart = () -> Bool
         private typealias OnMove = (GestureRecognizer) -> ()
@@ -167,8 +167,7 @@ extension ItemReordering {
             super.init(target: target, action: action)
             
             self.addTarget(self, action: #selector(updated))
-            self.delegate = self
-            self.minimumPressDuration = 0.5
+            self.minimumPressDuration = 0
         }
         
         /// Applies the actions from the ``ReorderingActions`` to the gesture recognizer,
@@ -202,13 +201,19 @@ extension ItemReordering {
                 y: translation.y + initialPointAndCenterDiff.y
             )
         }
-                        
+
+        private var initialTouchPoint : CGPoint? = nil
+
         @objc private func updated()
         {
             switch self.state {
             case .possible: break
             case .began:
-                break
+                if self.onStart?() == true {
+                    initialTouchPoint = location(in: view)
+                } else {
+                    self.state = .cancelled
+                }
             case .changed:
                 self.onMove?(self)
 
@@ -222,16 +227,6 @@ extension ItemReordering {
                 
             @unknown default: listableInternalFatal()
             }
-        }
-
-        private var initialTouchPoint : CGPoint? = nil
-
-        public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-            let shouldStart = onStart?() ?? false
-            if shouldStart {
-                initialTouchPoint = location(in: view)
-            }
-            return shouldStart
         }
     }
 }

--- a/ListableUI/Sources/Item/ItemReordering.swift
+++ b/ListableUI/Sources/Item/ItemReordering.swift
@@ -151,7 +151,7 @@ extension ItemReordering {
     ///     }
     /// }
     /// ```
-    public class GestureRecognizer : UIPanGestureRecognizer
+    public class GestureRecognizer : UILongPressGestureRecognizer, UIGestureRecognizerDelegate
     {
         private typealias OnStart = () -> Bool
         private typealias OnMove = (GestureRecognizer) -> ()
@@ -167,9 +167,8 @@ extension ItemReordering {
             super.init(target: target, action: action)
             
             self.addTarget(self, action: #selector(updated))
-            
-            self.minimumNumberOfTouches = 1
-            self.maximumNumberOfTouches = 1
+            self.delegate = self
+            self.minimumPressDuration = 0.5
         }
         
         /// Applies the actions from the ``ReorderingActions`` to the gesture recognizer,
@@ -182,50 +181,57 @@ extension ItemReordering {
         }
         
         func reorderPosition(in collectionView : UIView) -> CGPoint? {
-            
-            guard let initial = self.initialCenter else {
+            guard
+                let initialPoint = self.initialTouchPoint,
+                let cell = self.view?.firstSuperview(ofType: UICollectionViewCell.self)
+            else {
                 return nil
             }
             
-            let translation = self.translation(in: collectionView)
+            let translation = self.location(in: collectionView)
             
+            let initialPointInCell = cell.convert(initialPoint, from: view)
+
+            let initialPointAndCenterDiff = CGPoint(
+                x: cell.contentView.center.x - initialPointInCell.x,
+                y: cell.contentView.center.y - initialPointInCell.y
+            )
+
             return CGPoint(
-                x: initial.x + translation.x,
-                y: initial.y + translation.y
+                x: translation.x + initialPointAndCenterDiff.x,
+                y: translation.y + initialPointAndCenterDiff.y
             )
         }
-        
-        private var initialCenter : CGPoint? = nil
-                
+                        
         @objc private func updated()
         {
             switch self.state {
             case .possible: break
             case .began:
-                let center = self.view?.firstSuperview(ofType: UICollectionViewCell.self)?.center
-                
-                if let center = center {
-                    if self.onStart?() == true {
-                        self.initialCenter = center
-                    } else {
-                        self.state = .cancelled
-                    }
-                } else {
-                    self.state = .cancelled
-                }
+                break
             case .changed:
                 self.onMove?(self)
 
             case .ended:
                 self.onEnd?(.finished)
-                self.initialCenter = nil
+                self.initialTouchPoint = nil
                 
             case .cancelled, .failed:
                 self.onEnd?(.cancelled)
-                self.initialCenter = nil
+                self.initialTouchPoint = nil
                 
             @unknown default: listableInternalFatal()
             }
+        }
+
+        private var initialTouchPoint : CGPoint? = nil
+
+        public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            let shouldStart = onStart?() ?? false
+            if shouldStart {
+                initialTouchPoint = location(in: view)
+            }
+            return shouldStart
         }
     }
 }


### PR DESCRIPTION
_Describe your changes here. Please include screenshots if they're visual!_

- `[ItemReordering.GestureRecognizer` - Now it is a `UILongPressGestureRecognizer`. Instead of reporting that the drag event started in the update method, we now have `gestureRecognizerShouldBegin` so we can catch exactly when the press duration requirement has passed.
- `[ListReorderGesture` - It now has `Begins`, an enum that configures the `GestureRecognizer`'s `minimumPressDuration`.

![2022-02-07 09-23-31 2022-02-07 09_23_47](https://user-images.githubusercontent.com/202801/152808163-c9802fdb-56a1-4bff-814f-dbf3dadce545.gif)



### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
