### PR TITLE
Fixed list measurements with container headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Main]
 
 ### Fixed
-- Fix measuring large titles in modals.
+- Fixed list measurements with container headers.
 
 ### Added
 - Item reordering is now possible when using VoiceOver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Main]
 
 ### Fixed
+- Fix measuring large titles in modals.
 
 ### Added
 - Item reordering is now possible when using VoiceOver.

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
@@ -79,7 +79,7 @@ final class PresentationState
         /// as well as for testing purposes.
         
         self.containerHeader = .init(state: SectionState.newHeaderFooterState(
-            with: content.header,
+            with: content.containerHeader,
             performsContentCallbacks: false
         ))
         


### PR DESCRIPTION
When measuring the content size in `ListView.contentSize`, the height of large titles would be omitted. This happened because the measuring presentation state was using the `header` instead of the `containerHeader` when building the state for measuring.

| Before | After |
|---|---|
![image](https://user-images.githubusercontent.com/16192914/159309212-9e74531c-51f5-4424-8132-02bd8d8db35b.png) | ![Simulator Screen Shot - SQ iPad 14 5 - 2022-03-21 at 11 39 28](https://user-images.githubusercontent.com/16192914/159309331-4a3508d4-b2b3-4f9a-9db5-a2c46e9a97fd.png) |

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
