### PR TITLE
Don't force inherit animations when updating blueprint content.

### DIFF
--- a/BlueprintUILists/Sources/BlueprintHeaderFooterContent.swift
+++ b/BlueprintUILists/Sources/BlueprintHeaderFooterContent.swift
@@ -116,15 +116,6 @@ public extension BlueprintHeaderFooterContent
         views.content.element = self.elementRepresentation.wrapInBlueprintEnvironmentFrom(environment: info.environment)
         views.background.element = self.background?.wrapInBlueprintEnvironmentFrom(environment: info.environment)
         views.pressed.element = self.pressedBackground?.wrapInBlueprintEnvironmentFrom(environment: info.environment)
-        
-        /// `BlueprintView` does not update its content until the next layout cycle.
-        /// Force that layout cycle within this method if we're updating an already on-screen
-        /// `ItemContent`, to ensure that we inherit any animation blocks we may be within.
-        if reason == .wasUpdated {
-            views.content.layoutIfNeeded()
-            views.background.layoutIfNeeded()
-            views.pressed.layoutIfNeeded()
-        }
     }
     
     static func createReusableContentView(frame: CGRect) -> ContentView {

--- a/BlueprintUILists/Sources/BlueprintItemContent.swift
+++ b/BlueprintUILists/Sources/BlueprintItemContent.swift
@@ -125,15 +125,6 @@ public extension BlueprintItemContent
         views.content.element = self.element(with: info).wrapInBlueprintEnvironmentFrom(environment: info.environment)
         views.background.element = self.backgroundElement(with: info)?.wrapInBlueprintEnvironmentFrom(environment: info.environment)
         views.selectedBackground.element = self.selectedBackgroundElement(with: info)?.wrapInBlueprintEnvironmentFrom(environment: info.environment)
-        
-        /// `BlueprintView` does not update its content until the next layout cycle.
-        /// Force that layout cycle within this method if we're updating an already on-screen
-        /// `ItemContent`, to ensure that we inherit any animation blocks we may be within.
-        if reason == .wasUpdated {
-            views.content.layoutIfNeeded()
-            views.background.layoutIfNeeded()
-            views.selectedBackground.layoutIfNeeded()
-        }
     }
     
     /// Creates the `BlueprintView` used to render the content of the item.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Removed
 
+- When using `BlueprintUILists`, layout is no longer forced during element updates. This will cause animations to no longer be inherited. Please use `.transition`, etc. to control animations.
+
 ### Changed
 
 ### Misc


### PR DESCRIPTION
This doesn't seem to be needed anymore. Animations still occur, I suspect later changes to unify layout passes fixed this.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
