### PR TITLE
Introduce content context

### DIFF
--- a/BlueprintUILists.podspec
+++ b/BlueprintUILists.podspec
@@ -26,6 +26,8 @@ Pod::Spec.new do |s|
       test_spec.source_files = 'BlueprintUILists/Tests/**/*.{swift}'
       test_spec.ios.resource_bundle = { 'BlueprintUIListsResources' => 'BlueprintUILists/Tests/Resources/**/*.*' }
 
+      test_spec.dependency 'BlueprintUICommonControls'
+
       test_spec.framework = 'XCTest'
 
       test_spec.libraries = 'swiftsimd', 'swiftCoreGraphics', 'swiftFoundation', 'swiftUIKit'

--- a/BlueprintUILists/Sources/List.ContentContext.swift
+++ b/BlueprintUILists/Sources/List.ContentContext.swift
@@ -1,0 +1,25 @@
+//
+//  List.ContentContext.swift
+//  BlueprintUILists
+//
+//  Created by Kyle Van Essen on 6/10/22.
+//
+
+import BlueprintUI
+import ListableUI
+
+
+public enum ListContentContextKey : EnvironmentKey {
+    public static let defaultValue: ContentContext? = nil
+}
+
+
+extension Environment {
+    
+    public var listContentContext : ContentContext? {
+        get { self[ListContentContextKey.self] }
+        set { self[ListContentContextKey.self] = newValue }
+    }
+}
+
+

--- a/BlueprintUILists/Sources/List.ContentContext.swift
+++ b/BlueprintUILists/Sources/List.ContentContext.swift
@@ -9,13 +9,11 @@ import BlueprintUI
 import ListableUI
 
 
-public enum ListContentContextKey : EnvironmentKey {
-    public static let defaultValue: ContentContext? = nil
-}
-
-
 extension Environment {
     
+    /// Applies the provided `ContentContext` to the list when it's updated by Blueprint.
+    ///
+    /// See `ContentContext` for more information.
     public var listContentContext : ContentContext? {
         get { self[ListContentContextKey.self] }
         set { self[ListContentContextKey.self] = newValue }
@@ -23,3 +21,6 @@ extension Environment {
 }
 
 
+public enum ListContentContextKey : EnvironmentKey {
+    public static let defaultValue: ContentContext? = nil
+}

--- a/BlueprintUILists/Sources/List.swift
+++ b/BlueprintUILists/Sources/List.swift
@@ -161,13 +161,17 @@ extension List {
         
         public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription?
         {
-            ListView.describe { config in
+            var properties = self.properties
+            
+            properties.context = properties.context ?? context.environment.listContentContext
+            
+            return ListView.describe { config in
                 config.builder = {
-                    ListView(frame: context.bounds, appearance: self.properties.appearance)
+                    ListView(frame: context.bounds, appearance: properties.appearance)
                 }
                 
                 config.apply { listView in
-                    listView.configure(with: self.properties)
+                    listView.configure(with: properties)
                 }
             }
         }

--- a/BlueprintUILists/Tests/ListTests.swift
+++ b/BlueprintUILists/Tests/ListTests.swift
@@ -5,8 +5,12 @@
 //  Created by Kyle Van Essen on 10/26/20.
 //
 
+@testable import ListableUI
+
 import XCTest
 import BlueprintUI
+import BlueprintUICommonControls
+
 
 @testable import BlueprintUILists
 
@@ -22,18 +26,22 @@ class ListTests : XCTestCase {
             callCount += 1
         }
         
+        let onEnvRead = { (env:Environment) in
+            XCTAssertTrue(env[TestingKey.self])
+        }
+        
         view.element = List { list in
             
-            list.header = TestHeaderContent(wasCalled: callback)
-            list.footer = TestHeaderContent(wasCalled: callback)
+            list.header = TestHeaderContent(wasCalled: callback, onEnvRead: onEnvRead)
+            list.footer = TestHeaderContent(wasCalled: callback, onEnvRead: onEnvRead)
             
             list("section") { section in
                 
-                section.header = TestHeaderContent(wasCalled: callback)
-                section.footer = TestHeaderContent(wasCalled: callback)
+                section.header = TestHeaderContent(wasCalled: callback, onEnvRead: onEnvRead)
+                section.footer = TestHeaderContent(wasCalled: callback, onEnvRead: onEnvRead)
                 
-                section += TestItemContent(wasCalled: callback)
-                section += TestItemContent(wasCalled: callback)
+                section += TestItemContent(wasCalled: callback, onEnvRead: onEnvRead)
+                section += TestItemContent(wasCalled: callback, onEnvRead: onEnvRead)
             }
         }.adaptedEnvironment { env in
             env[TestingKey.self] = true
@@ -103,19 +111,65 @@ class ListTests : XCTestCase {
             CGSize(width: 900, height: 1000)
         )
     }
+    
+    func test_listContentContext() {
+        let view = BlueprintView(frame: CGRect(x: 0, y: 0, width: 200, height: 400))
+        
+        func configure(list: inout ListProperties) {
+            list.header = TestHeaderContent()
+            list.footer = TestHeaderContent()
+            
+            list("section") { section in
+                
+                section.header = TestHeaderContent()
+                section.footer = TestHeaderContent()
+                
+                section += TestItemContent()
+                section += TestItemContent()
+            }
+        }
+        
+        view.element = List { list in
+            configure(list: &list)
+        }.adaptedEnvironment(keyPath: \.listContentContext, value: .init(false))
+        
+        view.layoutIfNeeded()
+        
+        let listView = view.findListView()!
+        
+        var didResetSizesCount = 0
+        
+        listView.storage.presentationState.onResetCachedSizes = {
+            didResetSizesCount += 1
+        }
+        
+        // Do it twice, should only be called once since the value is the same.
+
+        for _ in 1...2 {
+            view.element = List { list in
+                configure(list: &list)
+            }.adaptedEnvironment(keyPath: \.listContentContext, value: .init(true))
+        }
+        
+        view.layoutIfNeeded()
+        
+        XCTAssertEqual(didResetSizesCount, 1)
+    }
 }
 
 
 fileprivate struct TestHeaderContent : BlueprintHeaderFooterContent {
     
-    var wasCalled : () -> ()
+    var wasCalled : () -> () = {}
+    
+    var onEnvRead : (Environment) -> () = { _ in }
     
     var elementRepresentation: Element {
         self.wasCalled()
         
         return EnvironmentReader { env in
-            XCTAssertTrue(env[TestingKey.self])
-            return Empty()
+            onEnvRead(env)
+            return Box(backgroundColor: .red).constrainedTo(height: .absolute(60))
         }
     }
     
@@ -123,7 +177,7 @@ fileprivate struct TestHeaderContent : BlueprintHeaderFooterContent {
         self.wasCalled()
         
         return EnvironmentReader { env in
-            XCTAssertTrue(env[TestingKey.self])
+            onEnvRead(env)
             return Empty()
         }
     }
@@ -132,7 +186,7 @@ fileprivate struct TestHeaderContent : BlueprintHeaderFooterContent {
         self.wasCalled()
         
         return EnvironmentReader { env in
-            XCTAssertTrue(env[TestingKey.self])
+            onEnvRead(env)
             return Empty()
         }
     }
@@ -144,8 +198,10 @@ fileprivate struct TestHeaderContent : BlueprintHeaderFooterContent {
 
 
 fileprivate struct TestItemContent : BlueprintItemContent {
+        
+    var wasCalled : () -> () = {}
     
-    var wasCalled : () -> ()
+    var onEnvRead : (Environment) -> () = { _ in }
     
     var identifierValue: String {
         ""
@@ -155,8 +211,8 @@ fileprivate struct TestItemContent : BlueprintItemContent {
         self.wasCalled()
         
         return EnvironmentReader { env in
-            XCTAssertTrue(env[TestingKey.self])
-            return Empty()
+            onEnvRead(env)
+            return Box(backgroundColor: .blue).constrainedTo(height: .absolute(40))
         }
     }
     
@@ -164,7 +220,7 @@ fileprivate struct TestItemContent : BlueprintItemContent {
         self.wasCalled()
         
         return EnvironmentReader { env in
-            XCTAssertTrue(env[TestingKey.self])
+            onEnvRead(env)
             return Empty()
         }
     }
@@ -173,7 +229,7 @@ fileprivate struct TestItemContent : BlueprintItemContent {
         self.wasCalled()
         
         return EnvironmentReader { env in
-            XCTAssertTrue(env[TestingKey.self])
+            onEnvRead(env)
             return Empty()
         }
     }
@@ -187,5 +243,21 @@ fileprivate struct TestItemContent : BlueprintItemContent {
 fileprivate struct TestingKey : EnvironmentKey {
     static var defaultValue: Bool {
         false
+    }
+}
+
+
+fileprivate extension UIView {
+    
+    func findListView() -> ListView? {
+        if let list = self as? ListView {
+            return list
+        }
+        
+        for subview in subviews {
+            return subview.findListView()
+        }
+        
+        return nil
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Introduce `ContentContext`, an `Equatable` value which represents the overall context for all content presented in a list. Eg, you might pass a theme here, the traits for your screen (eg, dark mode, a11y settings, etc), or any other value which when changed, should cause the entire list to re-render. If the `ContentContext` changes across list renders, all list measurements will be thrown out and re-measured during the next render pass.
+
 ### Removed
 
 ### Changed

--- a/ListableUI/Sources/Content.swift
+++ b/ListableUI/Sources/Content.swift
@@ -19,6 +19,13 @@ public struct Content
     /// the list will reload without animation.
     public var identifier : AnyHashable?
 
+    /// The context for the entire list content.
+    /// If this value changes, all measurements will be discarded and re-measured.
+    ///
+    /// While this can incur a performance hit, it can also simplify code: if your screen's traits
+    /// change, pass them in here vs requiring every item to check the screen traits.
+    public var context : ContentContext?
+    
     /// The refresh control, if any, associated with the list.
     public var refreshControl : RefreshControl?
     
@@ -104,6 +111,7 @@ public struct Content
     /// All parameters are optional, pass only what you need to customize.
     public init(
         identifier : AnyHashable? = nil,
+        context : ContentContext? = nil,
         refreshControl : RefreshControl? = nil,
         containerHeader : AnyHeaderFooterConvertible? = nil,
         header : AnyHeaderFooterConvertible? = nil,
@@ -112,6 +120,7 @@ public struct Content
         sections : [Section] = []
     ) {
         self.identifier = identifier
+        self.context = context
         
         self.refreshControl = refreshControl
         

--- a/ListableUI/Sources/Content.swift
+++ b/ListableUI/Sources/Content.swift
@@ -19,10 +19,10 @@ public struct Content
     /// the list will reload without animation.
     public var identifier : AnyHashable?
 
-    /// The context for the entire list content.
+    /// The context for the entire list.
     /// If this value changes, all measurements will be discarded and re-measured.
     ///
-    /// While this can incur a performance hit, it can also simplify code: if your screen's traits
+    /// Using the `ContentContext` can simplify code: If your screen's traits
     /// change, pass them in here vs requiring every item to check the screen traits.
     public var context : ContentContext?
     

--- a/ListableUI/Sources/ContentContext.swift
+++ b/ListableUI/Sources/ContentContext.swift
@@ -8,11 +8,30 @@
 import Foundation
 
 
+/// An `Equatable` value which represents the overall context for all content presented in a list.
+///
+/// Eg, you might pass a theme here, the traits for your screen (eg, dark mode, a11y settings, etc), or
+/// any other value which when changed, should cause the entire list to re-render.
+///
+/// If the `ContentContext` changes across list renders, all list measurements will be thrown out
+/// and re-measured during the next render pass.
+///
+/// ```
+/// listView.content.context = .init(
+///     MyTraits(textSize: .medium)
+/// )
+///
+/// // Changing to large will cause the list to re-render all contents.
+/// listView.content.context = .init(
+///     MyTraits(textSize: .large)
+/// )
+/// ```
 public struct ContentContext : Equatable {
     
     private let value : Any
     private let isEqual : (Any) -> Bool
     
+    /// Creates a new context with the provided `Equatable` value.
     public init<Value:Equatable>(_ value : Value) {
         self.value = value
         self.isEqual = { other in

--- a/ListableUI/Sources/ContentContext.swift
+++ b/ListableUI/Sources/ContentContext.swift
@@ -1,0 +1,28 @@
+//
+//  ContentContext.swift
+//  ListableUI
+//
+//  Created by Kyle Van Essen on 6/10/22.
+//
+
+import Foundation
+
+
+public struct ContentContext : Equatable {
+    
+    private let value : Any
+    private let isEqual : (Any) -> Bool
+    
+    public init<Value:Equatable>(_ value : Value) {
+        self.value = value
+        self.isEqual = { other in
+            guard let other = other as? Value else { return false}
+            
+            return value == other
+        }
+    }
+    
+    public static func == (lhs : ContentContext, rhs : ContentContext) -> Bool {
+        lhs.isEqual(rhs.value)
+    }
+}

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.SectionState.swift
@@ -50,6 +50,15 @@ extension PresentationState
             }
         }
         
+        func resetAllCachedSizes() {
+            self.header.state?.resetCachedSizes()
+            self.footer.state?.resetCachedSizes()
+            
+            self.items.forEach { item in
+                item.resetCachedSizes()
+            }
+        }
+        
         func removeItem(at index : Int) -> AnyPresentationItemState
         {
             self.model.items.remove(at: index)

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
@@ -18,6 +18,14 @@ final class PresentationState
         
     var refreshControl : RefreshControlState?
     
+    var context : ContentContext? {
+        didSet {
+            guard oldValue != context else { return }
+            
+            self.resetAllCachedSizes()
+        }
+    }
+    
     let containerHeader : HeaderFooterViewStatePair
     let header : HeaderFooterViewStatePair
     let footer : HeaderFooterViewStatePair
@@ -260,13 +268,21 @@ final class PresentationState
     // MARK: Height Caching
     //
     
+    // Exposed for testing only.
+    var onResetCachedSizes : () -> () = {}
+    
     func resetAllCachedSizes()
     {
+        containerHeader.state?.resetCachedSizes()
+        header.state?.resetCachedSizes()
+        footer.state?.resetCachedSizes()
+        overscrollFooter.state?.resetCachedSizes()
+        
         self.sections.forEach { section in
-            section.items.forEach { item in
-                item.resetCachedSizes()
-            }
+            section.resetAllCachedSizes()
         }
+        
+        onResetCachedSizes()
     }
     
     //

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -756,10 +756,13 @@ public final class ListView : UIView, KeyboardObserverDelegate
     private func setContentFromSource(animated : Bool = false)
     {
         let oldIdentifier = self.storage.allContent.identifier
-        self.storage.allContent = self.sourcePresenter.reloadContent()
-        let newIdentifier = self.storage.allContent.identifier
         
+        self.storage.allContent = self.sourcePresenter.reloadContent()
+        
+        let newIdentifier = self.storage.allContent.identifier
         let identifierChanged = oldIdentifier != newIdentifier
+        
+        self.storage.presentationState.context = self.storage.allContent.context
         
         self.updatePresentationState(for: .contentChanged(animated: animated, identifierChanged: identifierChanged))
     }

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -437,6 +437,73 @@ class ListViewTests: XCTestCase
             XCTAssertEqual(reappliedIDs, [])
         }
     }
+    
+    func test_content_context() {
+        
+        let view = ListView()
+        view.frame.size = CGSize(width: 200, height: 400)
+        
+        func configure(list : inout ListProperties) {
+            list.header = HeaderFooter(
+                ReapplySupplementary1(title: "title", reappliesToVisibleView: .ifNotEquivalent) {},
+                sizing: .fixed(height: 50)
+            )
+            
+            list.footer = HeaderFooter(
+                ReapplySupplementary1(title: "title", reappliesToVisibleView: .ifNotEquivalent) {},
+                sizing: .fixed(height: 50)
+            )
+            
+            list("section") { section in
+                section.header = HeaderFooter(
+                    ReapplySupplementary1(title: "title", reappliesToVisibleView: .ifNotEquivalent) {},
+                    sizing: .fixed(height: 50)
+                )
+                
+                section.footer = HeaderFooter(
+                    ReapplySupplementary1(title: "changed footer", reappliesToVisibleView: .ifNotEquivalent) {},
+                    sizing: .fixed(height: 50)
+                )
+                
+                section += Item(
+                    ReapplyContent(title: "row", id: 1, reappliesToVisibleView: .ifNotEquivalent) {},
+                    sizing: .fixed(height: 50)
+                )
+            }
+        }
+     
+        view.configure { list in
+            
+            list.context = ContentContext(false)
+            
+            configure(list: &list)
+        }
+        
+        /// Force the cells in the collection view to be updated.
+        view.collectionView.layoutIfNeeded()
+        
+        var didResetSizesCount = 0
+        
+        view.storage.presentationState.onResetCachedSizes = {
+            didResetSizesCount += 1
+        }
+        
+        // Do it twice, should only be called once since the value is the same.
+
+        for _ in 1...2 {
+            view.configure { list in
+                
+                list.context = ContentContext(true)
+                
+                configure(list: &list)
+            }
+        }
+        
+        /// Force the cells in the collection view to be updated.
+        view.collectionView.layoutIfNeeded()
+        
+        XCTAssertEqual(didResetSizesCount, 1)
+    }
 }
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,6 +7,7 @@ PODS:
     - ListableUI
   - BlueprintUILists/Tests (4.2.0):
     - BlueprintUI
+    - BlueprintUICommonControls
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
   - ListableUI (4.2.0)
@@ -45,7 +46,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 6c2191b97d47dfbefee7109b8bc1d5851a46dcea
   BlueprintUICommonControls: e70234cee8c023c9a02b93c58f48ac25d1083b0b
-  BlueprintUILists: b710b9d583565ef111deb843ceb521baa96408f4
+  BlueprintUILists: 97202d58fc9839e5b9e74b4fe76e9ab5b9b8aac8
   EnglishDictionary: f03968b9382ddc5c8dd63535efbf783c6cd45f1c
   ListableUI: 0eb0830ed82b2603714dad2835bdbde72869a019
   Snapshot: cda3414db426919d09f775434b36289c8e864183


### PR DESCRIPTION
This introduces the ability to provide a `Context` to `Content`, which is used to fully invalidate the caches sizes of elements (and eventually, any other cross-update cached values). This allows us to, eg, in `Market`, globally invalidate sizing when the `MarketTraits` change; since basically no one ever implements their `isEquivalent` correctly to do this. It'd be nice if people did this, but whatever, they don't, so this helps fix it.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
