### PR TITLE
Add ListHeaderPosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- `stickyListHeader` has been replaced with `listHeaderPosition`, which has three possible values: `inline`, `sticky`, and `fixed`.
+
 ### Misc
 
 # Past Releases

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -41,7 +41,7 @@ extension LayoutDescription
                 itemToSectionFooterSpacing: 10.0
             )
 
-            $0.stickyListHeader = true
+            $0.listHeaderPosition = .fixed
             $0.stickySectionHeaders = true
             
             configure(&$0)

--- a/ListableUI/Sources/Layout/Flow/FlowListLayout.swift
+++ b/ListableUI/Sources/Layout/Flow/FlowListLayout.swift
@@ -106,8 +106,8 @@ public struct FlowAppearance : ListLayoutAppearance {
     /// The direction the flow layout will be laid out in.
     public var direction: LayoutDirection
 
-    /// If the list header should stick to the top when scrolled.
-    public var stickyListHeader: Bool
+    /// How the list header should be positioned when content is scrolled.
+    public var listHeaderPosition: ListHeaderPosition
     
     /// If sections should have sticky headers, staying visible until the section is scrolled off screen.
     public var stickySectionHeaders: Bool
@@ -163,7 +163,7 @@ public struct FlowAppearance : ListLayoutAppearance {
     ) {
         self.direction = direction
 
-        self.stickyListHeader = false
+        self.listHeaderPosition = .inline
 
         self.stickySectionHeaders = {
             if let stickySectionHeaders = stickySectionHeaders {

--- a/ListableUI/Sources/Layout/ListLayout/ListHeaderPosition.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListHeaderPosition.swift
@@ -1,0 +1,13 @@
+/// How the list header should be positioned when content is scrolled.
+public enum ListHeaderPosition {
+
+    /// The header will scroll up and down with the content.
+    case inline
+
+    /// The header will stick to the top of the content when it's scrolled down, and bounce with content when
+    /// it's scrolled up (identical to how sticky section headers behave).
+    case sticky
+
+    /// The header is always positioned at the top of the visible frame, and does not bounce with the content.
+    case fixed
+}

--- a/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
@@ -73,8 +73,8 @@ extension ListLayout
         self.layoutAppearance.bounds
     }
 
-    public var stickyListHeader: Bool {
-        self.layoutAppearance.stickyListHeader
+    public var listHeaderPosition: ListHeaderPosition {
+        self.layoutAppearance.listHeaderPosition
     }
     
     public var stickySectionHeaders: Bool {
@@ -106,7 +106,7 @@ public protocol AnyListLayout : AnyObject
     
     var bounds : ListContentBounds? { get }
 
-    var stickyListHeader : Bool { get }
+    var listHeaderPosition : ListHeaderPosition { get }
 
     var stickySectionHeaders : Bool { get }
     
@@ -208,7 +208,7 @@ extension AnyListLayout
 
     public func positionStickyListHeaderIfNeeded(in collectionView: UICollectionView)
     {
-        guard self.stickyListHeader else { return }
+        guard self.listHeaderPosition != .inline else { return }
 
         let visibleContentFrame = self.visibleContentFrame(for: collectionView)
 
@@ -217,7 +217,7 @@ extension AnyListLayout
         let headerOrigin = self.direction.y(for: header.defaultFrame.origin)
         let visibleContentOrigin = self.direction.y(for: visibleContentFrame.origin)
 
-        if headerOrigin < visibleContentOrigin {
+        if headerOrigin < visibleContentOrigin || listHeaderPosition == .fixed {
 
             // Make sure the pinned origin stays within the list's frame.
 
@@ -243,7 +243,10 @@ extension AnyListLayout
         
         var visibleContentFrame = self.visibleContentFrame(for: collectionView)
 
-        if self.stickyListHeader {
+        switch listHeaderPosition {
+        case .inline:
+            break
+        case .sticky, .fixed:
             let listHeaderHeight = self.direction.height(for: self.content.header.size)
             self.direction.switch {
                 visibleContentFrame.size.height -= listHeaderHeight

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutAppearance.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutAppearance.swift
@@ -18,7 +18,7 @@ public protocol ListLayoutAppearance : Equatable
     
     var bounds : ListContentBounds? { get }
 
-    var stickyListHeader : Bool { get }
+    var listHeaderPosition : ListHeaderPosition { get }
 
     var stickySectionHeaders : Bool { get }
 

--- a/ListableUI/Sources/Layout/Paged/PagedListLayout.swift
+++ b/ListableUI/Sources/Layout/Paged/PagedListLayout.swift
@@ -62,7 +62,7 @@ public struct PagedAppearance : ListLayoutAppearance
     /// The direction the paging layout should occur in. Defaults to `vertical`.
     public var direction: LayoutDirection
 
-    public let stickyListHeader: Bool = false
+    public let listHeaderPosition: ListHeaderPosition = .inline
 
     public let stickySectionHeaders: Bool = false
     

--- a/ListableUI/Sources/Layout/Retail Grid/RetailGridListLayout.swift
+++ b/ListableUI/Sources/Layout/Retail Grid/RetailGridListLayout.swift
@@ -30,7 +30,7 @@ public struct RetailGridAppearance : ListLayoutAppearance
         .vertical
     }
 
-    public var stickyListHeader: Bool = false
+    public var listHeaderPosition: ListHeaderPosition = .inline
     
     public var stickySectionHeaders : Bool = false
     

--- a/ListableUI/Sources/Layout/Table/TableListLayout.swift
+++ b/ListableUI/Sources/Layout/Table/TableListLayout.swift
@@ -109,9 +109,9 @@ public struct TableAppearance : ListLayoutAppearance
     /// How the layout should flow, either horizontally or vertically.
     public var direction: LayoutDirection
 
-    /// If the list header should stick to the top when scrolled.
-    public var stickyListHeader: Bool
-    
+    /// How the list header should be positioned when content is scrolled.
+    public var listHeaderPosition: ListHeaderPosition
+
     /// If sticky section headers should be leveraged in the layout.
     public var stickySectionHeaders : Bool
     
@@ -157,7 +157,7 @@ public struct TableAppearance : ListLayoutAppearance
     /// Creates a new `TableAppearance` object.
     public init(
         direction : LayoutDirection = .vertical,
-        stickListHeader: Bool = false,
+        listHeaderPosition: ListHeaderPosition = .inline,
         stickySectionHeaders : Bool = true,
         pagingBehavior : ListPagingBehavior = .none,
         itemPositionGroupingHeight : CGFloat = 0.0,
@@ -167,7 +167,7 @@ public struct TableAppearance : ListLayoutAppearance
         layout : Layout = .init()
     ) {
         self.direction = direction
-        self.stickyListHeader = stickListHeader
+        self.listHeaderPosition = listHeaderPosition
         self.stickySectionHeaders = stickySectionHeaders
         self.pagingBehavior = pagingBehavior
         self.itemPositionGroupingHeight = itemPositionGroupingHeight


### PR DESCRIPTION
Adds a third option for position list headers: `fixed`, which will not bounce with the content.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
