### PR TITLE
Ensure we respect defaults values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 # Past Releases
 
+# [5.0.1] - 2022-07-19
+
+### Fixed
+
+- Ensure `Optional` values from `DefaultItemProperties` and `DefaultHeaderFooterProperties` are respected.
+
 # [5.0.0] - 2022-07-18
 
 ### Added
@@ -692,7 +698,8 @@ listActions.scrolling.scrollToSection(
 Earlier releases were ad-hoc and not tracked. To see all changes, please reference [closed PRs on Github](https://github.com/kyleve/Listable/pulls?q=is%3Apr+is%3Aclosed).
 
 
-[Main]: https://github.com/kyleve/Listable/compare/5.0.0...HEAD
+[Main]: https://github.com/kyleve/Listable/compare/5.0.1...HEAD
+[5.0.1]: https://github.com/kyleve/Listable/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/kyleve/Listable/compare/4.4.0...5.0.0
 [4.4.0]: https://github.com/kyleve/Listable/compare/4.3.1...4.4.0
 [4.3.1]: https://github.com/kyleve/Listable/compare/4.3.0...4.3.1

--- a/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
@@ -53,8 +53,8 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
         
         let defaults = self.content.defaultHeaderFooterProperties
         
-        self.sizing = finalValue(from: sizing, defaults.sizing, .thatFits(.noConstraint))
-        self.layouts = finalValue(from: layouts, defaults.layouts, .init())
+        self.sizing = sizing ?? defaults.sizing ?? .thatFits(.noConstraint)
+        self.layouts = layouts ?? defaults.layouts ?? .init()
         
         self.onTap = onTap
         
@@ -158,21 +158,5 @@ extension HeaderFooter : SignpostLoggable
             identifier: self.debuggingIdentifier,
             instanceIdentifier: nil
         )
-    }
-}
-
-
-private func finalValue<Value>(
-    from provided : Value?,
-    _ contentDefault : Value?,
-    _ default : @autoclosure () -> Value
-) -> Value
-{
-    if let value = provided {
-        return value
-    } else if let value = contentDefault {
-        return value
-    } else {
-        return `default`()
     }
 }

--- a/ListableUI/Sources/Item/Item.swift
+++ b/ListableUI/Sources/Item/Item.swift
@@ -93,11 +93,11 @@ public struct Item<Content:ItemContent> : AnyItem, AnyItemConvertible
         
         let defaults = self.content.defaultItemProperties
         
-        self.sizing = finalValue(from: sizing, defaults.sizing, .thatFits(.noConstraint))
-        self.layouts = finalValue(from: layouts, defaults.layouts, .init())
-        self.selectionStyle = finalValue(from: selectionStyle, defaults.selectionStyle, .notSelectable)
-        self.insertAndRemoveAnimations = finalValue(from: insertAndRemoveAnimations, defaults.insertAndRemoveAnimations, nil)
-        self.swipeActions = finalValue(from: swipeActions, defaults.swipeActions, nil)
+        self.sizing = sizing ?? defaults.sizing ?? .thatFits(.noConstraint)
+        self.layouts = layouts ?? defaults.layouts ?? .init()
+        self.selectionStyle = selectionStyle ?? defaults.selectionStyle ?? .notSelectable
+        self.insertAndRemoveAnimations = insertAndRemoveAnimations ?? defaults.insertAndRemoveAnimations ?? nil
+        self.swipeActions = swipeActions ?? defaults.swipeActions ?? nil
         
         self.reordering = reordering
         self.onWasReordered = onWasReordered
@@ -253,21 +253,5 @@ extension Item : SignpostLoggable
             identifier: self.debuggingIdentifier,
             instanceIdentifier: self.identifier.debugDescription
         )
-    }
-}
-
-
-private func finalValue<Value>(
-    from provided : Value?,
-    _ contentDefault : Value?,
-    _ default : @autoclosure () -> Value
-) -> Value
-{
-    if let value = provided {
-        return value
-    } else if let value = contentDefault {
-        return value
-    } else {
-        return `default`()
     }
 }

--- a/ListableUI/Tests/Item/ItemTests.swift
+++ b/ListableUI/Tests/Item/ItemTests.swift
@@ -5,9 +5,57 @@
 //  Created by Kyle Van Essen on 11/27/19.
 //
 
+import ListableUI
 import XCTest
 
 class ItemTests: XCTestCase
 {
+    func test_defaultValues() {
+        
+        let content = TestContent(
+            name: "test",
+            defaultItemProperties: .defaults { defaults in
+                defaults.swipeActions = .init(
+                    action: .init(
+                        title: "Test",
+                        backgroundColor: .blue,
+                        handler: { _ in }
+                    )
+                )
+            }
+        )
+        
+        // Make sure the defaults are actually passed through.
+        
+        let item = Item(content)
+        
+        XCTAssertEqual(item.swipeActions?.actions.count, 1)
+        XCTAssertEqual(item.swipeActions?.actions[0].title, "Test")
+    }
+}
 
+fileprivate struct TestContent : ItemContent {
+    
+    typealias ContentView = UIView
+    typealias IdentifierValue = String
+    
+    var name : String
+    
+    var defaultItemProperties: DefaultProperties = .defaults()
+    
+    var identifierValue: String {
+        name
+    }
+    
+    func isEquivalent(to other: TestContent) -> Bool {
+        true
+    }
+    
+    static func createReusableContentView(frame: CGRect) -> UIView {
+        UIView(frame: frame)
+    }
+    
+    func apply(to views: ItemContentViews<TestContent>, for reason: ApplyReason, with info: ApplyItemContentInfo) {
+        
+    }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (0.40.0)
   - BlueprintUICommonControls (0.40.0):
     - BlueprintUI (= 0.40.0)
-  - BlueprintUILists (5.0.0):
+  - BlueprintUILists (5.0.1):
     - BlueprintUI
     - ListableUI
-  - BlueprintUILists/Tests (5.0.0):
+  - BlueprintUILists/Tests (5.0.1):
     - BlueprintUI
     - BlueprintUICommonControls
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (5.0.0)
-  - ListableUI/Tests (5.0.0):
+  - ListableUI (5.0.1)
+  - ListableUI/Tests (5.0.1):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 6c2191b97d47dfbefee7109b8bc1d5851a46dcea
   BlueprintUICommonControls: e70234cee8c023c9a02b93c58f48ac25d1083b0b
-  BlueprintUILists: 47a1abbd61ee5bf6340024f50c9f9a20ae4dad8d
+  BlueprintUILists: 584468489361b548aa6a63ec7ee66b3e9b706744
   EnglishDictionary: f03968b9382ddc5c8dd63535efbf783c6cd45f1c
-  ListableUI: 24ab6590433866db5b0a1449998f191c3eb66fb2
+  ListableUI: eb848fcd874761a086b5f32d4f3e96901e347b38
   Snapshot: cda3414db426919d09f775434b36289c8e864183
 
 PODFILE CHECKSUM: 505f47e09640e9b7eadef9a138cfeed056359f76

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-LISTABLE_VERSION ||= '5.0.0'
+LISTABLE_VERSION ||= '5.0.1'


### PR DESCRIPTION
Fixes an issue where `Optional` default values would get stamped, because passing them through to the func ends up doubly wrapping them to `Optional?` (aka `Value??`, of which the inner one is always `.some(nil)`.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
