### PR TITLE
Introduce tint color to DefaultSwipeAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 ### Added
+- Added a tint color to `SwipeAction` to configure `DefaultSwipeActionsView`. This allows customization of the text and image color (assuming a template image is used), where previously they were always white.  
 
 ### Removed
 

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -98,7 +98,8 @@ final class SwipeActionsViewController: UIViewController  {
             SwipeAction(
                 title: item.isSaved ? "Unsave" : "Save",
                 backgroundColor: UIColor(displayP3Red: 0, green: 0.741, blue: 0.149, alpha: 1),
-                image: nil
+                tintColor: UIColor(red: 0.1843, green: 0.4, blue: 0.1922, alpha: 1.0),
+                image: item.isSaved ? nil : UIImage(named: "bookmark")!.withRenderingMode(.alwaysTemplate)
             ) { [weak self] expandActions in
                 self?.toggleSave(item: item)
                 expandActions(false)

--- a/ListableUI/Sources/Internal/DefaultSwipeView.swift
+++ b/ListableUI/Sources/Internal/DefaultSwipeView.swift
@@ -199,7 +199,6 @@ private class DefaultSwipeActionButton: UIButton {
         super.init(frame: frame)
 
         titleLabel?.font = .systemFont(ofSize: 15, weight: .medium)
-        tintColor = .white
         contentEdgeInsets = UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
         addTarget(self, action: #selector(onTap), for: .primaryActionTriggered)
     }
@@ -214,6 +213,9 @@ private class DefaultSwipeActionButton: UIButton {
         backgroundColor = action.backgroundColor
         setTitle(action.title, for: .normal)
         setImage(action.image, for: .normal)
+        
+        tintColor = action.tintColor
+        setTitleColor(action.tintColor, for: .normal)
     }
 
     @objc private func onTap() {

--- a/ListableUI/Sources/SwipeActionsConfiguration.swift
+++ b/ListableUI/Sources/SwipeActionsConfiguration.swift
@@ -62,6 +62,7 @@ public struct SwipeAction {
 
     public var title: String?
     public var backgroundColor: UIColor?
+    public var tintColor: UIColor
     public var image: UIImage?
 
     public var handler: Handler
@@ -70,11 +71,13 @@ public struct SwipeAction {
     public init(
         title: String,
         backgroundColor: UIColor,
+        tintColor: UIColor = .white,
         image: UIImage? = nil,
         handler: @escaping Handler
     ) {
         self.title = title
         self.backgroundColor = backgroundColor
+        self.tintColor = tintColor
         self.image = image
         self.handler = handler
     }

--- a/ListableUI/Sources/SwipeActionsConfiguration.swift
+++ b/ListableUI/Sources/SwipeActionsConfiguration.swift
@@ -62,6 +62,7 @@ public struct SwipeAction {
 
     public var title: String?
     public var backgroundColor: UIColor?
+    /// Sets the text and image (image must use the template rendering mode) color.
     public var tintColor: UIColor
     public var image: UIImage?
 


### PR DESCRIPTION
Introduces the ability to provide a tint color to a `SwipeAction`. This will color a template image and the text color of the action. Previously, all text was white. White is now the default. 

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog]


(https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
![Simulator Screen Shot - iPhone 12 - 2022-07-19 at 13 25 24](https://user-images.githubusercontent.com/2245012/179846711-3aa1c09d-1306-4580-8848-ee9ce7eda884.png)

