### PR TITLE
Don't inset horizontal lists for the keyboard, its meaningless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fix an issue where horizontal list views would erroneously inset for the keyboard. Horizontal lists should not adjust for the keyboard, since it ends up causing vertical scrolling.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/EmbeddedList.swift
+++ b/ListableUI/Sources/EmbeddedList.swift
@@ -15,7 +15,7 @@ public extension Item where Content == EmbeddedList
     /// list, or vice versa.
     ///
     /// ```
-    /// section += .list(
+    /// section += Item.list(
     ///     "my-identifier",
     ///     sizing: .fixed(height: 200)
     /// ) { list in

--- a/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
+++ b/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
@@ -186,3 +186,19 @@ public protocol AnyLayoutDescriptionConfiguration
     
     func isEqual(to other : AnyLayoutDescriptionConfiguration) -> Bool
 }
+
+
+extension LayoutDescription {
+    
+    var wantsKeyboardInsetAdjustment : Bool {
+        layoutAppearanceProperties.direction == .vertical
+    }
+    
+    func needsCollectionViewInsetUpdate(for other : LayoutDescription) -> Bool {
+        guard self.layoutAppearanceProperties.direction == other.layoutAppearanceProperties.direction else {
+            return true
+        }
+        
+        return false
+    }
+}

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -205,9 +205,15 @@ public final class ListView : UIView, KeyboardObserverDelegate
         set { self.set(layout: newValue, animated: false) }
     }
 
-    public func set(layout : LayoutDescription, animated : Bool = false, completion : @escaping () -> () = {})
+    public func set(layout new : LayoutDescription, animated : Bool = false, completion : @escaping () -> () = {})
     {
-        self.layoutManager.set(layout: layout, animated: animated, completion: completion)
+        let needsInsetUpdate = layout.needsCollectionViewInsetUpdate(for: new)
+        
+        self.layoutManager.set(layout: new, animated: animated, completion: completion)
+        
+        if needsInsetUpdate {
+            self.updateScrollViewInsets()
+        }
     }
     
     public var contentSize : CGSize {
@@ -306,6 +312,10 @@ public final class ListView : UIView, KeyboardObserverDelegate
         let keyboardBottomInset : CGFloat = {
             
             guard let keyboardFrame = keyboardFrame else {
+                return 0.0
+            }
+            
+            guard layout.wantsKeyboardInsetAdjustment else {
                 return 0.0
             }
             


### PR DESCRIPTION
Discovered this one in the Retail app, it resulted in horizontal lists being also able to pan around _vertically_, which is definitely wrong.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
