### PR TITLE
Header layout fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Fixed
 
+- Fixed an issue where `ListHeaderPosition.fixed` would cause the list header to overlap with the container header by falling back to `sticky` behavior if there's a container header.
+- Supplementary items will now animate when their position in the layout changes.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -13,55 +13,55 @@ final class CollectionViewLayout : UICollectionViewLayout
     //
     // MARK: Properties
     //
-    
+
     unowned let delegate : CollectionViewLayoutDelegate
-    
+
     var layoutDescription : LayoutDescription
-    
+
     var appearance : Appearance {
         didSet {
             guard oldValue != self.appearance else {
                 return
             }
-            
+
             self.applyAppearance()
         }
     }
-    
+
     private(set) var isReordering : Bool = false
-    
+
     private func applyAppearance()
     {
         guard self.collectionView != nil else {
             return
         }
-        
-        self.setNeedsRebuild()
+
+        self.setNeedsRebuild(animated: false)
     }
-    
+
     var behavior : Behavior {
         didSet {
             guard oldValue != self.behavior else {
                 return
             }
-            
+
             self.applyBehavior()
         }
     }
-    
+
     private func applyBehavior()
     {
         guard self.collectionView != nil else {
             return
         }
-        
-        self.setNeedsRebuild()
+
+        self.setNeedsRebuild(animated: false)
     }
-    
+
     //
     // MARK: Initialization
     //
-    
+
     init(
         delegate : CollectionViewLayoutDelegate,
         layoutDescription : LayoutDescription,
@@ -72,99 +72,105 @@ final class CollectionViewLayout : UICollectionViewLayout
         self.layoutDescription = layoutDescription
         self.appearance = appearance
         self.behavior = behavior
-        
+
         self.layout = self.layoutDescription.configuration.createEmptyLayout(
             appearance: appearance,
             behavior: behavior
         )
-        
+
         self.previousLayout = self.layout
-        
+
         self.changesDuringCurrentUpdate = UpdateItems(with: [])
-        
+
         self.viewProperties = CollectionViewLayoutProperties()
-        
+
         super.init()
-        
+
         self.applyAppearance()
         self.applyBehavior()
     }
-    
+
     @available(*, unavailable)
     required init?(coder: NSCoder) { listableInternalFatal() }
-    
+
     //
     // MARK: Querying The Layout
     //
-    
+
     func frameForItem(at indexPath : IndexPath) -> CGRect
     {
         self.layout.content.item(at: indexPath).frame
     }
-    
+
     func positionForItem(at indexPath : IndexPath) -> ItemPosition
     {
         self.layout.content.item(at: indexPath).position
     }
-    
+
     //
     // MARK: Private Properties
     //
-    
+
     private(set) var layout : AnyListLayout
-    
+
     private var previousLayout : AnyListLayout
     private var changesDuringCurrentUpdate : UpdateItems
     private var viewProperties : CollectionViewLayoutProperties
-    
+
     //
     // MARK: Invalidation & Invalidation Contexts
     //
-    
+
     func setNeedsRelayout()
     {
         self.neededLayoutType.merge(with: .relayout)
-        
+
         self.invalidateLayout()
     }
-    
-    func setNeedsRebuild()
+
+    func setNeedsRebuild(animated: Bool)
     {
         self.neededLayoutType.merge(with: .rebuild)
-        
-        self.invalidateLayout()
+
+        if animated {
+            /// The collection view actually manages the animation, and the duration or curve doesn't matter.
+            /// However, we need to be in an animation block for it to animate.
+            UIView.animate(withDuration: 0.15, animations: invalidateLayout)
+        } else {
+            self.invalidateLayout()
+        }
     }
-    
+
     private(set) var shouldAskForItemSizesDuringLayoutInvalidation : Bool = false
-    
+
     func setShouldAskForItemSizesDuringLayoutInvalidation()
     {
         self.shouldAskForItemSizesDuringLayoutInvalidation = true
     }
-    
+
     override class var invalidationContextClass: AnyClass {
         return InvalidationContext.self
     }
-    
+
     override func invalidateLayout()
     {
         super.invalidateLayout()
-        
+
         if self.shouldAskForItemSizesDuringLayoutInvalidation {
             self.neededLayoutType = .rebuild
             self.shouldAskForItemSizesDuringLayoutInvalidation = false
         }
     }
-    
+
     override func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext)
     {
         let view = self.collectionView!
         let context = context as! InvalidationContext
-        
+
         // Handle Moved Items
-                
+
         if let action = context.interactiveMoveAction {
-            
+
             switch action {
             case .inProgress(let info):
                 if info.from != info.to {
@@ -179,20 +185,20 @@ final class CollectionViewLayout : UICollectionViewLayout
                 self.sendEndQueuingEditsAfterDelay()
             }
         }
-        
+
         super.invalidateLayout(with: context)
-        
+
         // Handle View Width Changing
-        
+
         context.viewPropertiesChanged = self.viewProperties != CollectionViewLayoutProperties(collectionView: view)
-        
+
         // Update Needed Layout Type
-                
+
         self.neededLayoutType.merge(with: context)
     }
-    
+
     private func sendEndQueuingEditsAfterDelay() {
-        
+
         ///
         /// Hello! Welcome to the source code. You're probably wondering why this perform after runloop hack is here.
         ///
@@ -213,13 +219,13 @@ final class CollectionViewLayout : UICollectionViewLayout
         ///
         /// So thus, we queue updates a runloop to let the collection view figure its internal state out before we begin
         /// processing any further updates 🥴.
-        /// 
-        
+        ///
+
         OperationQueue.main.addOperation {
             self.delegate.listViewShouldEndQueueingEditsForReorder()
         }
     }
-    
+
     override func invalidationContext(
         forInteractivelyMovingItems targetIndexPaths: [IndexPath],
         withTargetPosition targetPosition: CGPoint,
@@ -228,7 +234,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     ) -> UICollectionViewLayoutInvalidationContext
     {
         self.isReordering = true
-        
+
         let context = super.invalidationContext(
             forInteractivelyMovingItems: targetIndexPaths,
             withTargetPosition: targetPosition,
@@ -244,10 +250,10 @@ final class CollectionViewLayout : UICollectionViewLayout
                 toPosition: targetPosition
             )
         )
-        
+
         return context
     }
-    
+
     override func invalidationContextForEndingInteractiveMovementOfItems(
         toFinalIndexPaths indexPaths: [IndexPath],
         previousIndexPaths: [IndexPath],
@@ -255,16 +261,16 @@ final class CollectionViewLayout : UICollectionViewLayout
     ) -> UICollectionViewLayoutInvalidationContext
     {
         self.isReordering = false
-        
+
         let context = super.invalidationContextForEndingInteractiveMovementOfItems(
             toFinalIndexPaths: indexPaths,
             previousIndexPaths: previousIndexPaths,
             movementCancelled: movementCancelled
         ) as! InvalidationContext
-        
+
         context.interactiveMoveAction = {
             if movementCancelled {
-                 return .cancelled(
+                return .cancelled(
                     .init(
                         from: previousIndexPaths,
                         to: indexPaths
@@ -279,26 +285,26 @@ final class CollectionViewLayout : UICollectionViewLayout
                 )
             }
         }()
-                                
+
         return context
     }
-    
+
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool
     {
         return true
     }
-    
+
     private final class InvalidationContext : UICollectionViewLayoutInvalidationContext
     {
         var viewPropertiesChanged : Bool = false
-        
+
         var interactiveMoveAction : InteractiveMoveAction? = nil
-        
+
         enum InteractiveMoveAction {
             case inProgress(InProgress)
             case complete(Complete)
             case cancelled(Cancelled)
-            
+
             var shouldRelayout : Bool {
                 switch self {
                 case .inProgress(let info):
@@ -309,57 +315,57 @@ final class CollectionViewLayout : UICollectionViewLayout
                     return true
                 }
             }
-            
+
             struct InProgress {
                 var from : [IndexPath]
                 var fromPosition : CGPoint
-                
+
                 var to : [IndexPath]
                 var toPosition : CGPoint
             }
-            
+
             struct Complete {
                 var from : [IndexPath]
                 var to : [IndexPath]
             }
-            
+
             struct Cancelled {
                 var from : [IndexPath]
                 var to : [IndexPath]
             }
         }
     }
-    
+
     //
     // MARK: Preparing For Layouts
     //
-    
+
     private enum NeededLayoutType {
         case none
         case relayout
         case rebuild
-        
+
         mutating func merge(with context : UICollectionViewLayoutInvalidationContext)
         {
             let context = context as! InvalidationContext
-            
+
             let requeryDataSourceCounts = context.invalidateEverything || context.invalidateDataSourceCounts
             let needsRelayout = context.viewPropertiesChanged || context.interactiveMoveAction?.shouldRelayout ?? false
-            
+
             if requeryDataSourceCounts {
                 self.merge(with: .rebuild)
             } else if needsRelayout {
                 self.merge(with: .relayout)
             }
         }
-        
+
         mutating func merge(with new : NeededLayoutType)
         {
             if new.priority > self.priority {
                 self = new
             }
         }
-        
+
         private var priority : Int {
             switch self {
             case .none: return 0
@@ -367,7 +373,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             case .rebuild: return 2
             }
         }
-        
+
         mutating func update(with success : Bool)
         {
             if success {
@@ -375,23 +381,23 @@ final class CollectionViewLayout : UICollectionViewLayout
             }
         }
     }
-    
+
     private var neededLayoutType : NeededLayoutType = .rebuild
-        
+
     override func prepare()
     {
         super.prepare()
 
         self.changesDuringCurrentUpdate = UpdateItems(with: [])
-                        
+
         let size = self.collectionView?.bounds.size ?? .zero
-        
+
         self.neededLayoutType.update(with: {
-            
+
             // Layouts with zero area are undefined,
             // so skip them until the view has a size.
             let shouldLayout = size.isEmpty == false
-            
+
             switch self.neededLayoutType {
             case .none:
                 return true
@@ -400,43 +406,43 @@ final class CollectionViewLayout : UICollectionViewLayout
             case .rebuild:
                 self.performRebuild(andLayout: shouldLayout)
             }
-            
+
             return true
         }())
-        
+
         self.performLayoutUpdate()
-        
+
         if self.isReordering == false {
             self.delegate.listViewLayoutDidLayoutContents()
         }
     }
-    
+
     override func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem])
     {
         super.prepare(forCollectionViewUpdates: updateItems)
-        
+
         self.changesDuringCurrentUpdate = UpdateItems(with: updateItems)
     }
-    
+
     //
     // MARK: Finishing Layouts
     //
-    
+
     override func finalizeCollectionViewUpdates()
     {
         super.finalizeCollectionViewUpdates()
-        
+
         self.changesDuringCurrentUpdate = UpdateItems(with: [])
     }
-    
+
     //
     // MARK: Performing Layouts
     //
-    
+
     private func performRebuild(andLayout layout : Bool)
     {
         self.previousLayout = self.layout
-        
+
         self.layout = self.layoutDescription.configuration.createPopulatedLayout(
             appearance: self.appearance,
             behavior: self.behavior,
@@ -444,40 +450,40 @@ final class CollectionViewLayout : UICollectionViewLayout
                 self.delegate.listLayoutContent(defaults: $0)
             }
         )
-        
+
         self.layout.scrollViewProperties.apply(
             to: self.collectionView!,
             behavior: self.behavior,
             direction: self.layout.direction,
             showsScrollIndicators: self.appearance.showsScrollIndicators
         )
-                
+
         if layout {
             self.performLayout()
         }
     }
-    
+
     private func performLayout()
     {
         let view = self.collectionView!
-                
+
         let context = ListLayoutLayoutContext(
             collectionView: view,
             environment: self.delegate.listViewLayoutCurrentEnvironment()
         )
-        
+
         self.layout.performLayout(
             with: self.delegate,
             in: context
         )
-                
+
         self.viewProperties = CollectionViewLayoutProperties(collectionView: view)
     }
-    
+
     private func performLayoutUpdate()
     {
         let view = self.collectionView!
-        
+
         let context = ListLayoutLayoutContext(
             collectionView: view,
             environment: self.delegate.listViewLayoutCurrentEnvironment()
@@ -485,14 +491,14 @@ final class CollectionViewLayout : UICollectionViewLayout
 
         self.layout.positionStickyListHeaderIfNeeded(in: view)
         self.layout.positionStickySectionHeadersIfNeeded(in: view)
-        
+
         self.layout.updateLayout(in: context)
     }
-    
+
     //
     // MARK: UICollectionViewLayout Methods
     //
-    
+
     override var collectionViewContentSize : CGSize
     {
         return self.layout.content.contentSize
@@ -502,7 +508,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     {
         return self.layout.content.layoutAttributes(in: rect, alwaysIncludeOverscroll: true)
     }
-    
+
     func visibleLayoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]?
     {
         return self.layout.content.layoutAttributes(in: rect, alwaysIncludeOverscroll: false)
@@ -512,16 +518,16 @@ final class CollectionViewLayout : UICollectionViewLayout
     {
         return self.layout.content.layoutAttributes(at: indexPath)
     }
-    
+
     public override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> UICollectionViewLayoutAttributes?
     {
         return self.layout.content.supplementaryLayoutAttributes(of: elementKind, at: indexPath)
     }
-    
+
     //
     // MARK: UICollectionViewLayout Methods: Insertions & Removals
     //
-    
+
     private func animations(for item : ListLayoutContent.ItemInfo) -> ItemInsertAndRemoveAnimations {
         if UIAccessibility.isReduceMotionEnabled {
             return .fade
@@ -538,7 +544,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             let item = self.layout.content.item(at: itemIndexPath)
             let attributes = item.layoutAttributes(with: itemIndexPath)
             let animations = self.animations(for: item)
-            
+
             var properties = ListContentLayoutAttributes(attributes)
             animations.onInsert(&properties)
             properties.apply(to: attributes)
@@ -546,13 +552,13 @@ final class CollectionViewLayout : UICollectionViewLayout
             return attributes
         } else {
             let wasSectionInserted = self.changesDuringCurrentUpdate.insertedSections.contains(.init(newIndex: itemIndexPath.section))
-            
+
             let attributes = super.initialLayoutAttributesForAppearingItem(at: itemIndexPath)
-            
+
             if wasSectionInserted == false {
                 attributes?.alpha = 1.0
             }
-            
+
             return attributes
         }
     }
@@ -560,12 +566,12 @@ final class CollectionViewLayout : UICollectionViewLayout
     override func finalLayoutAttributesForDisappearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes?
     {
         let wasItemDeleted = self.changesDuringCurrentUpdate.deletedItems.contains(.init(oldIndexPath: itemIndexPath))
-        
+
         if wasItemDeleted {
             let item = self.previousLayout.content.item(at: itemIndexPath)
             let attributes = item.layoutAttributes(with: itemIndexPath)
             let animations = self.animations(for: item)
-            
+
             var properties = ListContentLayoutAttributes(attributes)
             animations.onRemoval(&properties)
             properties.apply(to: attributes)
@@ -573,57 +579,57 @@ final class CollectionViewLayout : UICollectionViewLayout
             return attributes
         } else {
             let wasSectionDeleted = self.changesDuringCurrentUpdate.deletedSections.contains(.init(oldIndex: itemIndexPath.section))
-            
+
             let attributes = super.finalLayoutAttributesForDisappearingItem(at: itemIndexPath)
-            
+
             if wasSectionDeleted == false {
                 attributes?.alpha = 1.0
             }
-            
+
             return attributes
         }
     }
-    
+
     override func initialLayoutAttributesForAppearingSupplementaryElement(ofKind elementKind: String, at elementIndexPath: IndexPath) -> UICollectionViewLayoutAttributes?
     {
         let wasInserted = self.changesDuringCurrentUpdate.insertedSections.contains(.init(newIndex: elementIndexPath.section))
         let attributes = super.initialLayoutAttributesForAppearingSupplementaryElement(ofKind: elementKind, at: elementIndexPath)
-        
+
         if wasInserted == false {
             attributes?.alpha = 1.0
         }
-        
+
         return attributes
     }
-    
+
     override func finalLayoutAttributesForDisappearingSupplementaryElement(ofKind elementKind: String, at elementIndexPath: IndexPath) -> UICollectionViewLayoutAttributes?
     {
         let wasDeleted = self.changesDuringCurrentUpdate.deletedSections.contains(.init(oldIndex: elementIndexPath.section))
         let attributes = super.finalLayoutAttributesForDisappearingSupplementaryElement(ofKind: elementKind, at: elementIndexPath)
-        
+
         if wasDeleted == false {
             attributes?.alpha = 1.0
         }
-        
+
         return attributes
     }
-    
+
     //
     // MARK: UICollectionViewLayout Methods: Moving Items
     //
-    
+
     override func targetIndexPath(
         forInteractivelyMovingItem previousIndexPath: IndexPath,
         withPosition position: CGPoint
     ) -> IndexPath {
-        
+
         /// TODO: The default implementation provided by `UICollectionView` does not work correctly
         /// when trying to move an item to the end of a section, or when trying to move an item into an
         /// empty section. We should add casing that allows moving into the section in these cases.
-        
+
         return super.targetIndexPath(forInteractivelyMovingItem: previousIndexPath, withPosition: position)
     }
-    
+
     override func layoutAttributesForInteractivelyMovingItem(
         at indexPath: IndexPath,
         withTargetPosition position: CGPoint
@@ -631,18 +637,18 @@ final class CollectionViewLayout : UICollectionViewLayout
     {
         let original = self.layout.content.layoutAttributes(at: indexPath)
         let current = super.layoutAttributesForInteractivelyMovingItem(at: indexPath, withTargetPosition: position)
-        
+
         var currentAttributes = ListContentLayoutAttributes(current)
-        
+
         self.layout.adjust(
             layoutAttributesForReorderingItem: &currentAttributes,
             originalAttributes: ListContentLayoutAttributes(original),
             at: indexPath,
             withTargetPosition: position
         )
-        
+
         currentAttributes.apply(to: current)
-        
+
         return current
     }
 }
@@ -654,25 +660,25 @@ final class CollectionViewLayout : UICollectionViewLayout
 
 
 struct CollectionViewLayoutProperties : Equatable
- {
-     let size : CGSize
-     let safeAreaInsets : UIEdgeInsets
-     let contentInset : UIEdgeInsets
+{
+    let size : CGSize
+    let safeAreaInsets : UIEdgeInsets
+    let contentInset : UIEdgeInsets
 
-     init()
-     {
-         self.size = .zero
-         self.safeAreaInsets = .zero
-         self.contentInset = .zero
-     }
+    init()
+    {
+        self.size = .zero
+        self.safeAreaInsets = .zero
+        self.contentInset = .zero
+    }
 
-     init(collectionView : UICollectionView)
-     {
-         self.size = collectionView.bounds.size
-         self.safeAreaInsets = collectionView.safeAreaInsets
-         self.contentInset = collectionView.contentInset
-     }
- }
+    init(collectionView : UICollectionView)
+    {
+        self.size = collectionView.bounds.size
+        self.safeAreaInsets = collectionView.safeAreaInsets
+        self.contentInset = collectionView.contentInset
+    }
+}
 
 
 //
@@ -682,15 +688,15 @@ struct CollectionViewLayoutProperties : Equatable
 public protocol CollectionViewLayoutDelegate : AnyObject
 {
     func listViewLayoutUpdatedItemPositions()
-    
+
     func listLayoutContent(
         defaults: ListLayoutDefaults
     ) -> ListLayoutContent
-    
+
     func listViewLayoutCurrentEnvironment() -> ListEnvironment
-    
+
     func listViewLayoutDidLayoutContents()
-    
+
     func listViewShouldEndQueueingEditsForReorder()
 }
 
@@ -703,68 +709,68 @@ fileprivate struct UpdateItems : Equatable
 {
     let insertedSections : Set<InsertSection>
     let deletedSections : Set<DeleteSection>
-    
+
     let insertedItems : Set<InsertItem>
     let deletedItems : Set<DeleteItem>
-    
+
     init(with updateItems : [UICollectionViewUpdateItem])
     {
-       var insertedSections = Set<InsertSection>()
-       var deletedSections = Set<DeleteSection>()
+        var insertedSections = Set<InsertSection>()
+        var deletedSections = Set<DeleteSection>()
 
-       var insertedItems = Set<InsertItem>()
-       var deletedItems = Set<DeleteItem>()
+        var insertedItems = Set<InsertItem>()
+        var deletedItems = Set<DeleteItem>()
 
-       for item in updateItems {
+        for item in updateItems {
             switch item.updateAction {
             case .insert:
                 let indexPath = item.indexPathAfterUpdate!
-                
+
                 if indexPath.item == NSNotFound {
                     insertedSections.insert(.init(newIndex: indexPath.section))
                 } else {
                     insertedItems.insert(.init(newIndexPath: indexPath))
                 }
-                
+
             case .delete:
                 let indexPath = item.indexPathBeforeUpdate!
-                
+
                 if indexPath.item == NSNotFound {
                     deletedSections.insert(.init(oldIndex: indexPath.section))
                 } else {
                     deletedItems.insert(.init(oldIndexPath: indexPath))
                 }
-                
+
             case .move: break
             case .reload: break
             case .none: break
-                
+
             @unknown default: listableInternalFatal()
             }
         }
-        
+
         self.insertedSections = insertedSections
         self.deletedSections = deletedSections
-        
+
         self.insertedItems = insertedItems
         self.deletedItems = deletedItems
     }
-    
+
     struct InsertSection : Hashable
     {
         var newIndex : Int
     }
-    
+
     struct DeleteSection : Hashable
     {
         var oldIndex : Int
     }
-    
+
     struct InsertItem : Hashable
     {
         var newIndexPath : IndexPath
     }
-    
+
     struct DeleteItem : Hashable
     {
         var oldIndexPath : IndexPath

--- a/ListableUI/Sources/Layout/ListLayout/ListHeaderPosition.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListHeaderPosition.swift
@@ -9,5 +9,8 @@ public enum ListHeaderPosition {
     case sticky
 
     /// The header is always positioned at the top of the visible frame, and does not bounce with the content.
+    ///
+    /// Note: This mode only works if the list has no container header. If there is a container header, the behavior
+    /// falls back to `sticky`.
     case fixed
 }

--- a/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
@@ -217,7 +217,10 @@ extension AnyListLayout
         let headerOrigin = self.direction.y(for: header.defaultFrame.origin)
         let visibleContentOrigin = self.direction.y(for: visibleContentFrame.origin)
 
-        if headerOrigin < visibleContentOrigin || listHeaderPosition == .fixed {
+        /// `fixed` only works if there's no `containerHeader`.
+        let shouldBeFixed =  listHeaderPosition == .fixed && !content.containerHeader.isPopulated
+
+        if headerOrigin < visibleContentOrigin || shouldBeFixed {
 
             // Make sure the pinned origin stays within the list's frame.
 

--- a/ListableUI/Sources/ListView/ListView.LayoutManager.swift
+++ b/ListableUI/Sources/ListView/ListView.LayoutManager.swift
@@ -14,35 +14,35 @@ extension ListView
     final class LayoutManager
     {
         unowned let collectionView : UICollectionView
-                
+
         private(set) var collectionViewLayout : CollectionViewLayout
-        
+
         var layout : AnyListLayout {
             collectionViewLayout.layout
         }
-        
+
         init(layout collectionViewLayout : CollectionViewLayout, collectionView : UICollectionView)
         {
             self.collectionViewLayout = collectionViewLayout
             self.collectionView = collectionView
         }
-        
+
         func stateForItem(at indexPath: IndexPath) -> AnyPresentationItemState {
             self.collectionViewLayout.layout.content.item(at: indexPath).state
         }
-        
+
         func set(layout : LayoutDescription, animated : Bool, completion : @escaping () -> ())
         {
             if self.collectionViewLayout.layoutDescription.configuration.isSameLayoutType(as: layout.configuration) {
                 self.collectionViewLayout.layoutDescription = layout
-                
+
                 let shouldRebuild = self.collectionViewLayout.layoutDescription.configuration.shouldRebuild(
                     layout: self.collectionViewLayout.layout
                 )
-                
+
                 if shouldRebuild {
                     /// TODO: We shouldn't need to rebuild in any case here; just push the new values through to the ListLayout.
-                    self.collectionViewLayout.setNeedsRebuild()
+                    self.collectionViewLayout.setNeedsRebuild(animated: animated)
                 }
             } else {
                 self.collectionViewLayout = CollectionViewLayout(
@@ -51,7 +51,7 @@ extension ListView
                     appearance: self.collectionViewLayout.appearance,
                     behavior: self.collectionViewLayout.behavior
                 )
-                
+
                 self.collectionView.setCollectionViewLayout(self.collectionViewLayout, animated: animated) { _ in
                     completion()
                 }


### PR DESCRIPTION
- Fall back to sticky for list header positioning if there's a container header
- Animate layout invalidation so supplementary views are animated when setting the layout

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
