### PR TITLE
Fix refresh control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed an issue where `ListHeaderPosition.fixed` would cause the list header to overlap with the refresh control by falling back to `sticky` behavior if there's a refresh control.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Layout/ListLayout/ListHeaderPosition.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListHeaderPosition.swift
@@ -10,7 +10,7 @@ public enum ListHeaderPosition {
 
     /// The header is always positioned at the top of the visible frame, and does not bounce with the content.
     ///
-    /// Note: This mode only works if the list has no container header. If there is a container header, the behavior
-    /// falls back to `sticky`.
+    /// Note: This mode only works if the list has no container header or refresh control. If there is a container
+    /// header or refresh control, the behavior falls back to `sticky` so the header doesn't overlap with those.
     case fixed
 }

--- a/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
@@ -218,7 +218,9 @@ extension AnyListLayout
         let visibleContentOrigin = self.direction.y(for: visibleContentFrame.origin)
 
         /// `fixed` only works if there's no `containerHeader`.
-        let shouldBeFixed =  listHeaderPosition == .fixed && !content.containerHeader.isPopulated
+        let shouldBeFixed = listHeaderPosition == .fixed
+            && !content.containerHeader.isPopulated
+            && collectionView.refreshControl == nil
 
         if headerOrigin < visibleContentOrigin || shouldBeFixed {
 

--- a/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayout.swift
@@ -217,7 +217,7 @@ extension AnyListLayout
         let headerOrigin = self.direction.y(for: header.defaultFrame.origin)
         let visibleContentOrigin = self.direction.y(for: visibleContentFrame.origin)
 
-        /// `fixed` only works if there's no `containerHeader`.
+        /// `fixed` only works if there's no `containerHeader` or `refreshControl` (those behave "inline" so fixing it would overlap).
         let shouldBeFixed = listHeaderPosition == .fixed
             && !content.containerHeader.isPopulated
             && collectionView.refreshControl == nil


### PR DESCRIPTION
Fixed an issue where `ListHeaderPosition.fixed` would cause the list header to overlap with the refresh control by falling back to `sticky` behavior if there's a refresh control.
### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
