### PR TITLE
Add accessibility parameters to SwipeAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `SwipeAction` now allows you to provide an `accessibility{Label,Value,Hint}`, and requires either a `title` or `accessibilityLabel`.
+
 ### Removed
 
 ### Changed

--- a/ListableUI/Sources/Internal/DefaultSwipeView.swift
+++ b/ListableUI/Sources/Internal/DefaultSwipeView.swift
@@ -209,13 +209,19 @@ private class DefaultSwipeActionButton: UIButton {
 
     func set(action: SwipeAction, didPerformAction: @escaping SwipeAction.CompletionHandler) {
         self.action = action
+        
         self.didPerformAction = didPerformAction
+        
         backgroundColor = action.backgroundColor
+        tintColor = action.tintColor
+        
         setTitle(action.title, for: .normal)
+        setTitleColor(action.tintColor, for: .normal)
         setImage(action.image, for: .normal)
         
-        tintColor = action.tintColor
-        setTitleColor(action.tintColor, for: .normal)
+        accessibilityLabel = action.accessibilityLabel
+        accessibilityValue = action.accessibilityValue
+        accessibilityHint = action.accessibilityHint
     }
 
     @objc private func onTap() {

--- a/ListableUI/Sources/SwipeActionsConfiguration.swift
+++ b/ListableUI/Sources/SwipeActionsConfiguration.swift
@@ -61,6 +61,11 @@ public struct SwipeAction {
     public typealias Handler = (@escaping CompletionHandler) -> Void
 
     public var title: String?
+    
+    public var accessibilityLabel : String?
+    public var accessibilityValue : String?
+    public var accessibilityHint : String?
+    
     public var backgroundColor: UIColor?
     /// Sets the text and image (image must use the template rendering mode) color.
     public var tintColor: UIColor
@@ -70,13 +75,27 @@ public struct SwipeAction {
     
     /// Creates a new swipe action with the provided options.
     public init(
-        title: String,
+        title: String?,
+        accessibilityLabel: String? = nil,
+        accessibilityValue: String? = nil,
+        accessibilityHint: String? = nil,
         backgroundColor: UIColor,
         tintColor: UIColor = .white,
         image: UIImage? = nil,
         handler: @escaping Handler
     ) {
+        if title == nil || title?.isEmpty == true {
+            precondition(
+                accessibilityLabel?.isEmpty == false,
+                "You must provide a title or an accessibilityLabel to a SwipeAction to ensure proper VoiceOver support."
+            )
+        }
+        
         self.title = title
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityValue = accessibilityValue
+        self.accessibilityHint = accessibilityHint
+        
         self.backgroundColor = backgroundColor
         self.tintColor = tintColor
         self.image = image


### PR DESCRIPTION
Some places in POS are passing no title, which means a11y won't work in those cases – add options for various a11y strings.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
