### PR TITLE
Move refresh control tint color to Appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Changed
 
+- The refresh control color has moved to `Appearance` from `RefreshControl`.
+
 ### Misc
 
 # Past Releases

--- a/ListableUI/Sources/Appearance.swift
+++ b/ListableUI/Sources/Appearance.swift
@@ -19,16 +19,22 @@ public struct Appearance : Equatable
     /// The background color for the list.
     @Color public var backgroundColor : UIColor
     
+    /// The tint color of the refresh control.
+    public var refreshControlColor : UIColor?
+    
     /// If the list should display its scroll indicators.
     public var showsScrollIndicators : Bool
         
     /// Creates a new appearance object with the provided options.
     public init(
         backgroundColor : UIColor = Self.defaultBackgroundColor,
+        refreshControlColor : UIColor? = nil,
         showsScrollIndicators : Bool = true,
         configure : (inout Self) -> () = { _ in }
     ) {
         self._backgroundColor = Color(backgroundColor)
+        
+        self.refreshControlColor = refreshControlColor
         
         self.showsScrollIndicators = showsScrollIndicators
         

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.RefreshControl.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.RefreshControl.swift
@@ -24,7 +24,7 @@ extension PresentationState
             self.view.addTarget(self, action: #selector(refreshControlChanged), for: .valueChanged)
         }
         
-        func update(with control : RefreshControl)
+        func update(with control : RefreshControl, color : UIColor?)
         {
             self.model = control
             
@@ -37,7 +37,9 @@ extension PresentationState
                 self.view.attributedTitle = nil
             }
             
-            self.view.tintColor = self.model.tintColor
+            if let color = color {
+                self.view.tintColor = color
+            }
             
             if self.model.isRefreshing {
                 self.view.beginRefreshing()

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
@@ -400,15 +400,15 @@ final class PresentationState
         )
     }
     
-    internal func updateRefreshControl(with new : RefreshControl?, in view : UIScrollView)
+    internal func updateRefreshControl(with new : RefreshControl?, in view : UIScrollView, color : UIColor?)
     {
         if let existing = self.refreshControl, let new = new {
-            existing.update(with: new)
+            existing.update(with: new, color: color)
         } else if self.refreshControl == nil, let new = new {
             let newControl = RefreshControlState(new)
             view.refreshControl = newControl.view
             self.refreshControl = newControl
-            newControl.update(with: new)
+            newControl.update(with: new, color: color)
         } else if self.refreshControl != nil, new == nil {
             view.refreshControl = nil
             self.refreshControl = nil

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1015,7 +1015,11 @@ public final class ListView : UIView, KeyboardObserverDelegate
          Note: Must be called *OUTSIDE* of CollectionView's `performBatchUpdates:`, otherwise
          we trigger a bug where updated indexes are calculated incorrectly.
          */
-        presentationState.updateRefreshControl(with: visibleSlice.content.refreshControl, in: self.collectionView)
+        presentationState.updateRefreshControl(
+            with: visibleSlice.content.refreshControl,
+            in: self.collectionView,
+            color: appearance.refreshControlColor
+        )
         
         // Update Collection View
         

--- a/ListableUI/Sources/RefreshControl.swift
+++ b/ListableUI/Sources/RefreshControl.swift
@@ -22,9 +22,6 @@ public struct RefreshControl
     /// The title of the control.
     public var title : Title?
     
-    /// The color of the control.
-    public var tintColor : UIColor?
-    
     public typealias OnRefresh = () -> ()
     
     /// Invoked when a customer triggers a refresh event.
@@ -34,7 +31,6 @@ public struct RefreshControl
         isRefreshing: Bool,
         offsetAdjustmentBehavior: OffsetAdjustmentBehavior = .none,
         title : Title? = nil,
-        tintColor : UIColor? = nil,
         onRefresh : @escaping OnRefresh
         )
     {
@@ -42,7 +38,6 @@ public struct RefreshControl
         self.offsetAdjustmentBehavior = offsetAdjustmentBehavior
 
         self.title = title
-        self.tintColor = tintColor
         
         self.onRefresh = onRefresh
     }


### PR DESCRIPTION
This will let us more easily provide a default color for it in `MarketScreenList`.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
