### PR TITLE
Always set tint, so if the tint goes back to nil, we'll set it still

### DIFF
--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.RefreshControl.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.RefreshControl.swift
@@ -37,9 +37,7 @@ extension PresentationState
                 self.view.attributedTitle = nil
             }
             
-            if let color = color {
-                self.view.tintColor = color
-            }
+            self.view.tintColor = color
             
             if self.model.isRefreshing {
                 self.view.beginRefreshing()


### PR DESCRIPTION
I realized the `if let ...` check was wrong: If you have a color, and then no color, we still want to set the `tintColor` to nil so it falls back to the system default.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
