### PR TITLE
Add .toggles selection type for toggle-style selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Introduces a `.toggles` selection type, to allow a second tap to deselect an item.
+
 ### Removed
 
 ### Changed

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -132,6 +132,17 @@ public final class DemosRootViewController : ListViewController
                 )
                 
                 Item(
+                    DemoItem(text: "Toggle Selection"),
+                    selectionStyle: .toggles(),
+                    onSelect : { _ in
+                        print("Selected")
+                    },
+                    onDeselect: { _ in
+                        print("Deselected")
+                    }
+                )
+                
+                Item(
                     DemoItem(text: "Invoices Payment Schedule"),
                     selectionStyle: .selectable(),
                     onSelect : { _ in

--- a/ListableUI/Sources/Item/ItemSelectionStyle.swift
+++ b/ListableUI/Sources/Item/ItemSelectionStyle.swift
@@ -20,11 +20,16 @@ public enum ItemSelectionStyle : Equatable
     /// The item is persistently selectable. Once the user lifts their finger, the item is maintained.
     case selectable(isSelected : Bool = false)
     
+    /// The item is persistently selectable. Once the user lifts their finger, the item is maintained.
+    /// If the user taps again, the item will be deselected.
+    case toggles(isSelected : Bool = false)
+    
     var isSelected : Bool {
         switch self {
         case .notSelectable: return false
         case .tappable: return false
         case .selectable(let selected): return selected
+        case .toggles(let selected): return selected
         }
     }
     
@@ -32,7 +37,8 @@ public enum ItemSelectionStyle : Equatable
         switch self {
         case .notSelectable: return false
         case .tappable: return true
-        case .selectable(_): return true
+        case .selectable: return true
+        case .toggles: return true
         }
     }
 }

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -52,7 +52,22 @@ extension ListView
             
             let item = self.presentationState.item(at: indexPath)
             
-            return item.anyModel.selectionStyle.isSelectable
+            if case .toggles = item.anyModel.selectionStyle {
+                
+                if item.isSelected {
+                    item.set(isSelected: false, performCallbacks: true)
+                    collectionView.deselectItem(at: indexPath, animated: false)
+                    item.applyToVisibleCell(with: self.view.environment)
+                    
+                    self.performOnSelectChanged()
+                    
+                    return false
+                } else {
+                    return true
+                }
+            } else {
+                return item.anyModel.selectionStyle.isSelectable
+            }
         }
         
         func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool


### PR DESCRIPTION
This allows the toggle-style interaction; where tapping once selects the row, and tapping again deselects it.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
