### PR TITLE
Update documentation for `LayoutDescription` and `ListProperties` to use new padding API

### DIFF
--- a/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
+++ b/ListableUI/Sources/Layout/ListLayout/LayoutDescription.swift
@@ -20,7 +20,7 @@ import Foundation
 /// listView.layout = .table {
 ///     $0.stickySectionHeaders = true
 ///
-///     $0.layout.padding = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+///     $0.bounds = .init(padding: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10))
 ///     $0.layout.itemSpacing = 10.0
 /// }
 /// ```

--- a/ListableUI/Sources/ListProperties.swift
+++ b/ListableUI/Sources/ListProperties.swift
@@ -83,7 +83,7 @@ import UIKit
     /// list.layout = .table {
     ///     $0.stickySectionHeaders = true
     ///
-    ///     $0.layout.padding = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+    ///     $0.bounds = .init(padding: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10))
     ///     $0.layout.itemSpacing = 10.0
     /// }
     /// ```


### PR DESCRIPTION
Looks like these docs still use the older padding API that was changed in #317(?)